### PR TITLE
docs: Update package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ While working on projects in nestjs it was very easy to get up and running with 
 
 Nestjs-query is composed of multiple packages
 
-* [`@nestjs-query/core`](https://github.com/tripss/nestjs-query/tree/master/packages/core) - Defines all interfaces and utility types implemented by the other packages.
-* [`@nestjs-query/query-graphql`](https://github.com/tripss/nestjs-query/tree/master/packages/query-graphql) - Package that provides the graphql resolver and decorators for crud endpoints.
-* [`@nestjs-query/query-mongoose`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typeorm) - Package that implements a Mongoose service that can be used by itself or with the graphql resolver provided by `@nestjs-query/query-graphql`.
-* [`@nestjs-query/query-sequelize`](https://github.com/tripss/nestjs-query/tree/master/packages/query-sequelize) - Package that implements a Sequelize service that can be used by itself or with the graphql resolver provided by `@nestjs-query/query-graphql`.
-* [`@nestjs-query/query-typegoose`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typegoose) - Package that implements a Typegoos service that can be used by itself or with the graphql resolver provided by `@nestjs-query/query-graphql`.
-* [`@nestjs-query/query-typeorm`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typeorm) - Package that implements a Typeorm service that can be used by itself or with the graphql resolver provided by `@nestjs-query/query-graphql`.
-
+* [`@ptc-org/nestjs-query-core`](https://github.com/tripss/nestjs-query/tree/master/packages/core) - Defines all interfaces and utility types implemented by the other packages.
+* [`@ptc-org/nestjs-query-graphql`](https://github.com/tripss/nestjs-query/tree/master/packages/query-graphql) - Package that provides the graphql resolver and decorators for crud endpoints.
+* [`@ptc-org/nestjs-query-mongoose`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typeorm) - Package that implements a Mongoose service that can be used by itself or with the graphql resolver provided by `@ptc-org/nestjs-query-graphql`.
+* [`@ptc-org/nestjs-query-sequelize`](https://github.com/tripss/nestjs-query/tree/master/packages/query-sequelize) - Package that implements a Sequelize service that can be used by itself or with the graphql resolver provided by `@ptc-org/nestjs-query-graphql`.
+* [`@ptc-org/nestjs-query-typegoose`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typegoose) - Package that implements a Typegoose service that can be used by itself or with the graphql resolver provided by `@ptc-org/nestjs-query-graphql`.
+* [`@ptc-org/nestjs-query-typeorm`](https://github.com/tripss/nestjs-query/tree/master/packages/query-typeorm) - Package that implements a Typeorm service that can be used by itself or with the graphql resolver provided by `@ptc-org/nestjs-query-graphql`.
 
 ## Development
+
 If you'd like to contribute to this project, all you need to do is clone this project and run:
 
 ```bash


### PR DESCRIPTION
Just updating the package names from @nestjs-query to @ptc-org in the readme and fixed the typo Typegoos -> Typegoose.