### PR TITLE
Upgrade typeorm to 0.2.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,6 @@
     "tsconfig-paths": "3.11.0",
     "typescript": "4.4.4"
   },
-  "packageManager": "yarn@3.2.1"
+  "packageManager": "yarn@3.2.1",
+  "version": "3.2.1"
 }

--- a/packages/query-typeorm/package.json
+++ b/packages/query-typeorm/package.json
@@ -29,7 +29,7 @@
     "@nestjs/common": "^8.0.4",
     "@nestjs/typeorm": "^8.0.0",
     "class-transformer": "^0.2.3 || 0.3.1 || 0.4",
-    "typeorm": "^0.2.25"
+    "typeorm": "0.2.45"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4090,7 +4090,7 @@ __metadata:
     "@nestjs/common": ^8.0.4
     "@nestjs/typeorm": ^8.0.0
     class-transformer: ^0.2.3 || 0.3.1 || 0.4
-    typeorm: ^0.2.25
+    typeorm: 0.2.45
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
0.2.45 is listed as a dependencies in `./package.json`. However, `query-typeorm/package.json` was listing `^0.2.25` as a peer dependency. This was causing the following error when I was trying to switch from the original repo

<details>
<summary>Error log</summary>

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: my-package@0.5.8
npm ERR! Found: typeorm@0.2.45
npm ERR! node_modules/typeorm
npm ERR!   typeorm@"^0.2.45" from the root project
npm ERR!   peer typeorm@"^0.2.25" from @ptc-org/nestjs-query-typeorm@1.0.0-alpha.5
npm ERR!   node_modules/@ptc-org/nestjs-query-typeorm
npm ERR!     @ptc-org/nestjs-query-typeorm@"*" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer typeorm@"^0.3.0" from @nestjs/typeorm@8.1.4
npm ERR! node_modules/@nestjs/typeorm
npm ERR!   @nestjs/typeorm@"^8.0.3" from the root project
npm ERR!   peer @nestjs/typeorm@"^8.0.0" from @ptc-org/nestjs-query-typeorm@1.0.0-alpha.5
npm ERR!   node_modules/@ptc-org/nestjs-query-typeorm
npm ERR!     @ptc-org/nestjs-query-typeorm@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```
</details>

I simply ran this command to upgrade:

```
yarn workspace @ptc-org/nestjs-query-typeorm add typeorm@0.2.45 -P --exact   
```