### PR TITLE
fix: class-transformer peer version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,6 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.4",
-    "class-transformer": "^0.2.3 || 0.3.1 || 0.4"
+    "class-transformer": "^0.2.3 || 0.3.1 || ^0.5"
   }
 }

--- a/packages/query-graphql/package.json
+++ b/packages/query-graphql/package.json
@@ -44,7 +44,7 @@
     "@nestjs/common": "^8.0.4",
     "@nestjs/core": "^8.0.4",
     "@nestjs/graphql": "^9.0.0",
-    "class-transformer": "^0.2.3 || 0.3.1 || 0.4",
+    "class-transformer": "^0.2.3 || 0.3.1 || ^0.5",
     "class-validator": "^0.13.0",
     "dataloader": "^2.0.0",
     "graphql": "^15.0.0",

--- a/packages/query-typeorm/package.json
+++ b/packages/query-typeorm/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.4",
     "@nestjs/typeorm": "^8.0.0",
-    "class-transformer": "^0.2.3 || 0.3.1 || 0.4",
+    "class-transformer": "^0.2.3 || 0.3.1 || ^0.5",
     "typeorm": "0.2.45"
   },
   "repository": {


### PR DESCRIPTION
Hi,

There is a small in compatibility with `class-transformer` 0.4.x.

> no plainToClass function exposed.

This pr remove the peer definition with it.