### PR TITLE
fix(deps): Update to use a better package for nestjs-typegoose

### DIFF
--- a/packages/query-typegoose/package.json
+++ b/packages/query-typegoose/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0",
-    "@typegoose/typegoose": "^8.0.0-beta.2",
+    "@typegoose/typegoose": "^8.0.0 || ^9.0.0",
     "mongoose": "^6.3.3",
     "@m8a/nestjs-typegoose": "8.0.5"
   },

--- a/packages/query-typegoose/package.json
+++ b/packages/query-typegoose/package.json
@@ -28,7 +28,7 @@
     "@nestjs/common": "^8.0.0 || ^9.0.0",
     "@typegoose/typegoose": "^8.0.0-beta.2",
     "mongoose": "^6.3.3",
-    "nestjs-typegoose": "^7.1.38"
+    "@m8a/nestjs-typegoose": "8.0.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,

I'm now maintaining the NestJS-Typegoose package under the @m8a project, since the original maintainer has stopped with its upkeep. If you could, please merge this PR, so consuming devs won't get unmet peer deps. Thanks. 

Scott