### PR TITLE
perf(query-typeorm): Use `= TRUE` instead of `IS TRUE` so indexes on …

### DIFF
--- a/packages/query-typeorm/__tests__/query/__snapshots__/where.builder.spec.ts.snap
+++ b/packages/query-typeorm/__tests__/query/__snapshots__/where.builder.spec.ts.snap
@@ -61,7 +61,7 @@ FROM
 WHERE
   ("TestEntity"."number_type" = 1)
   AND ("TestEntity"."string_type" LIKE foo%)
-  AND ("TestEntity"."bool_type" IS TRUE)
+  AND ("TestEntity"."bool_type" = TRUE)
 `;
 
 exports[`WhereBuilder and should properly group AND with a sibling field comparison 1`] = `

--- a/packages/query-typeorm/__tests__/query/sql-comparison.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/sql-comparison.builder.spec.ts
@@ -123,14 +123,14 @@ describe('SQLComparisonBuilder', (): void => {
   describe('is comparisons', () => {
     it('should build is true', (): void => {
       expect(createSQLComparisonBuilder().build('boolType', 'is', true, 'TestEntity')).toEqual({
-        sql: 'TestEntity.boolType IS TRUE',
+        sql: 'TestEntity.boolType = TRUE',
         params: {}
       })
     })
 
     it('should build is false', (): void => {
       expect(createSQLComparisonBuilder().build('boolType', 'is', false, 'TestEntity')).toEqual({
-        sql: 'TestEntity.boolType IS FALSE',
+        sql: 'TestEntity.boolType = FALSE',
         params: {}
       })
     })
@@ -153,14 +153,14 @@ describe('SQLComparisonBuilder', (): void => {
   describe('isNot comparisons', () => {
     it('should build is true', (): void => {
       expect(createSQLComparisonBuilder().build('boolType', 'isNot', true, 'TestEntity')).toEqual({
-        sql: 'TestEntity.boolType IS NOT TRUE',
+        sql: 'TestEntity.boolType != TRUE',
         params: {}
       })
     })
 
     it('should build is false', (): void => {
       expect(createSQLComparisonBuilder().build('boolType', 'isNot', false, 'TestEntity')).toEqual({
-        sql: 'TestEntity.boolType IS NOT FALSE',
+        sql: 'TestEntity.boolType != FALSE',
         params: {}
       })
     })

--- a/packages/query-typeorm/src/query/sql-comparison.builder.ts
+++ b/packages/query-typeorm/src/query/sql-comparison.builder.ts
@@ -105,10 +105,10 @@ export class SQLComparisonBuilder<Entity> {
       return { sql: `${col} IS NULL`, params: {} }
     }
     if (val === true) {
-      return { sql: `${col} IS TRUE`, params: {} }
+      return { sql: `${col} = TRUE`, params: {} }
     }
     if (val === false) {
-      return { sql: `${col} IS FALSE`, params: {} }
+      return { sql: `${col} = FALSE`, params: {} }
     }
     throw new Error(`unexpected is operator param ${JSON.stringify(val)}`)
   }
@@ -118,10 +118,10 @@ export class SQLComparisonBuilder<Entity> {
       return { sql: `${col} IS NOT NULL`, params: {} }
     }
     if (val === true) {
-      return { sql: `${col} IS NOT TRUE`, params: {} }
+      return { sql: `${col} != TRUE`, params: {} }
     }
     if (val === false) {
-      return { sql: `${col} IS NOT FALSE`, params: {} }
+      return { sql: `${col} != FALSE`, params: {} }
     }
     throw new Error(`unexpected isNot operator param ${JSON.stringify(val)}`)
   }


### PR DESCRIPTION
…boolean fields can be used