### PR TITLE
feat: Added multi hooks support

### DIFF
--- a/packages/query-graphql/__tests__/decorators/hook.decorator.spec.ts
+++ b/packages/query-graphql/__tests__/decorators/hook.decorator.spec.ts
@@ -13,7 +13,7 @@ import {
   Hook
 } from '@ptc-org/nestjs-query-graphql'
 
-import { getHookForType } from '../../src/decorators'
+import { getHooksForType } from '../../src/decorators'
 import { createDefaultHook, HookTypes } from '../../src/hooks'
 
 describe('hook decorators', () => {
@@ -24,8 +24,8 @@ describe('hook decorators', () => {
       @BeforeCreateOne(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -36,8 +36,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -51,8 +51,8 @@ describe('hook decorators', () => {
       @BeforeCreateOne(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_ONE, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -61,7 +61,7 @@ describe('hook decorators', () => {
       @BeforeCreateOne(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_CREATE_ONE, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_CREATE_ONE, Test)).toBe(MockHook)
     })
   })
 
@@ -72,8 +72,8 @@ describe('hook decorators', () => {
       @BeforeCreateMany(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -84,8 +84,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -99,8 +99,8 @@ describe('hook decorators', () => {
       @BeforeCreateMany(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_CREATE_MANY, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_CREATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -109,7 +109,7 @@ describe('hook decorators', () => {
       @BeforeCreateMany(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_CREATE_MANY, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_CREATE_MANY, Test)).toBe(MockHook)
     })
   })
 
@@ -120,8 +120,8 @@ describe('hook decorators', () => {
       @BeforeUpdateOne(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -132,8 +132,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -147,8 +147,8 @@ describe('hook decorators', () => {
       @BeforeUpdateOne(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -157,7 +157,7 @@ describe('hook decorators', () => {
       @BeforeUpdateOne(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_UPDATE_ONE, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_UPDATE_ONE, Test)).toBe(MockHook)
     })
   })
 
@@ -168,8 +168,8 @@ describe('hook decorators', () => {
       @BeforeUpdateMany(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -180,8 +180,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -195,8 +195,8 @@ describe('hook decorators', () => {
       @BeforeUpdateMany(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_UPDATE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -205,7 +205,7 @@ describe('hook decorators', () => {
       @BeforeUpdateMany(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_UPDATE_MANY, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_UPDATE_MANY, Test)).toBe(MockHook)
     })
   })
 
@@ -216,8 +216,8 @@ describe('hook decorators', () => {
       @BeforeDeleteOne(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -228,8 +228,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -243,8 +243,8 @@ describe('hook decorators', () => {
       @BeforeDeleteOne(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_ONE, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_ONE, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -253,7 +253,7 @@ describe('hook decorators', () => {
       @BeforeDeleteOne(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_DELETE_ONE, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_DELETE_ONE, Test)).toBe(MockHook)
     })
   })
 
@@ -264,8 +264,8 @@ describe('hook decorators', () => {
       @BeforeDeleteMany(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -276,8 +276,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -291,8 +291,8 @@ describe('hook decorators', () => {
       @BeforeDeleteMany(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_DELETE_MANY, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_DELETE_MANY, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -301,7 +301,7 @@ describe('hook decorators', () => {
       @BeforeDeleteMany(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_DELETE_MANY, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_DELETE_MANY, Test)).toBe(MockHook)
     })
   })
 
@@ -312,8 +312,8 @@ describe('hook decorators', () => {
       @BeforeQueryMany(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_QUERY_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_QUERY_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -324,8 +324,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_QUERY_MANY, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_QUERY_MANY, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -339,8 +339,8 @@ describe('hook decorators', () => {
       @BeforeQueryMany(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_QUERY_MANY, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_QUERY_MANY, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -349,7 +349,7 @@ describe('hook decorators', () => {
       @BeforeQueryMany(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_QUERY_MANY, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_QUERY_MANY, Test)).toBe(MockHook)
     })
   })
 
@@ -360,8 +360,8 @@ describe('hook decorators', () => {
       @BeforeFindOne(hookFn)
       class Test {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_FIND_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_FIND_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the base class', () => {
@@ -372,8 +372,8 @@ describe('hook decorators', () => {
 
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_FIND_ONE, Test)!
-      expect(new Stored().run).toBe(hookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_FIND_ONE, Test)!
+      expect(new Stored[0]().run).toBe(hookFn)
     })
 
     it('should return a hook from the child class if there is a hook on both the base and child', () => {
@@ -387,8 +387,8 @@ describe('hook decorators', () => {
       @BeforeFindOne(childHookFn)
       class Test extends Base {}
 
-      const Stored: Class<Hook<any>> = getHookForType(HookTypes.BEFORE_FIND_ONE, Test)!
-      expect(new Stored().run).toBe(childHookFn)
+      const Stored: Class<Hook<any>> = getHooksForType(HookTypes.BEFORE_FIND_ONE, Test)!
+      expect(new Stored[0]().run).toBe(childHookFn)
     })
 
     it('should return the hook class', () => {
@@ -397,7 +397,7 @@ describe('hook decorators', () => {
       @BeforeFindOne(MockHook)
       class Test {}
 
-      expect(getHookForType(HookTypes.BEFORE_FIND_ONE, Test)).toBe(MockHook)
+      expect(getHooksForType(HookTypes.BEFORE_FIND_ONE, Test)).toBe(MockHook)
     })
   })
 })

--- a/packages/query-graphql/src/decorators/hook-args.decorator.ts
+++ b/packages/query-graphql/src/decorators/hook-args.decorator.ts
@@ -31,7 +31,7 @@ function createArgsDecorator<T, C = unknown>(fn: (arg: T, context: C) => T | Pro
 
 export const HookArgs = <T>(): ParameterDecorator =>
   createArgsDecorator(async (data: T, context: HookContext<Hook<unknown>>) => {
-    if (context.hooks) {
+    if (context.hooks && context.hooks.length > 0) {
       let hookedArgs = data
       for (const hook of context.hooks) {
         hookedArgs = (await hook.run(hookedArgs, context)) as T
@@ -43,12 +43,12 @@ export const HookArgs = <T>(): ParameterDecorator =>
 
 export const MutationHookArgs = <T extends MutationArgsType<unknown>>(): ParameterDecorator =>
   createArgsDecorator(async (data: T, context: HookContext<Hook<unknown>>) => {
-    if (context.hooks) {
+    if (context.hooks && context.hooks.length > 0) {
       let hookedArgs = data
       for (const hook of context.hooks) {
         hookedArgs = (await hook.run(hookedArgs, context)) as T
       }
-      return hookedArgs;
+      return hookedArgs
     }
     return data
   })

--- a/packages/query-graphql/src/decorators/hook-args.decorator.ts
+++ b/packages/query-graphql/src/decorators/hook-args.decorator.ts
@@ -31,18 +31,24 @@ function createArgsDecorator<T, C = unknown>(fn: (arg: T, context: C) => T | Pro
 
 export const HookArgs = <T>(): ParameterDecorator =>
   createArgsDecorator(async (data: T, context: HookContext<Hook<unknown>>) => {
-    if (context.hook) {
-      const hookedArgs = await context.hook.run(data, context)
-      return hookedArgs as T
+    if (context.hooks) {
+      let hookedArgs = data
+      for (const hook of context.hooks) {
+        hookedArgs = (await hook.run(hookedArgs, context)) as T
+      }
+      return hookedArgs
     }
     return data
   })
 
 export const MutationHookArgs = <T extends MutationArgsType<unknown>>(): ParameterDecorator =>
   createArgsDecorator(async (data: T, context: HookContext<Hook<unknown>>) => {
-    if (context.hook) {
-      const { input } = data
-      return { input: await context.hook.run(input, context) } as T
+    if (context.hooks) {
+      let hookedArgs = data
+      for (const hook of context.hooks) {
+        hookedArgs = (await hook.run(hookedArgs, context)) as T
+      }
+      return hookedArgs;
     }
     return data
   })

--- a/packages/query-graphql/src/decorators/hook.decorator.ts
+++ b/packages/query-graphql/src/decorators/hook.decorator.ts
@@ -16,7 +16,7 @@ import {
   isHookClass
 } from '../hooks'
 
-export type HookMetaValue<H extends Hook<unknown>> = MetaValue<Class<H>>
+export type HookMetaValue<H extends Hook<unknown>> = MetaValue<Class<H>[]>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HookDecoratorArg<H extends Hook<unknown>> = Class<H> | H['run']
 
@@ -24,15 +24,23 @@ const hookMetaDataKey = (hookType: HookTypes): string => `nestjs-query:${hookTyp
 
 const hookDecorator = <H extends Hook<unknown>>(hookType: HookTypes) => {
   const key = hookMetaDataKey(hookType)
+
+  const getHook = (hook: HookDecoratorArg<H>) => {
+    if (isHookClass(hook)) {
+      return hook
+    }
+    const defaultHook = createDefaultHook(hook)
+    return defaultHook
+  }
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return (data: HookDecoratorArg<H>) =>
+  return (data: HookDecoratorArg<H> | HookDecoratorArg<H>[]) =>
     // eslint-disable-next-line @typescript-eslint/ban-types
     (target: Function): void => {
       if (isHookClass(data)) {
         return Reflect.defineMetadata(key, data, target)
       }
-      const hook = createDefaultHook(data)
-      return Reflect.defineMetadata(key, hook, target)
+      const hooks = Array.isArray(data) ? data.map((d) => getHook(d)) : [getHook(data)]
+      return Reflect.defineMetadata(key, hooks, target)
     }
 }
 
@@ -45,5 +53,5 @@ export const BeforeDeleteMany = hookDecorator<BeforeDeleteManyHook<any>>(HookTyp
 export const BeforeQueryMany = hookDecorator<BeforeQueryManyHook<any>>(HookTypes.BEFORE_QUERY_MANY)
 export const BeforeFindOne = hookDecorator<BeforeFindOneHook>(HookTypes.BEFORE_FIND_ONE)
 
-export const getHookForType = <H extends Hook<unknown>>(hookType: HookTypes, DTOClass: Class<unknown>): HookMetaValue<H> =>
+export const getHooksForType = <H extends Hook<unknown>>(hookType: HookTypes, DTOClass: Class<unknown>): HookMetaValue<H> =>
   getClassMetadata(DTOClass, hookMetaDataKey(hookType), true)

--- a/packages/query-graphql/src/decorators/hook.decorator.ts
+++ b/packages/query-graphql/src/decorators/hook.decorator.ts
@@ -33,13 +33,10 @@ const hookDecorator = <H extends Hook<unknown>>(hookType: HookTypes) => {
     return defaultHook
   }
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return (data: HookDecoratorArg<H> | HookDecoratorArg<H>[]) =>
+  return (...data: HookDecoratorArg<H>[]) =>
     // eslint-disable-next-line @typescript-eslint/ban-types
     (target: Function): void => {
-      if (isHookClass(data)) {
-        return Reflect.defineMetadata(key, data, target)
-      }
-      const hooks = Array.isArray(data) ? data.map((d) => getHook(d)) : [getHook(data)]
+      const hooks = data.map((d) => getHook(d))
       return Reflect.defineMetadata(key, hooks, target)
     }
 }

--- a/packages/query-graphql/src/providers/hook.provider.ts
+++ b/packages/query-graphql/src/providers/hook.provider.ts
@@ -1,7 +1,7 @@
 import { Provider } from '@nestjs/common'
 import { Class } from '@ptc-org/nestjs-query-core'
 
-import { getHookForType } from '../decorators'
+import { getHooksForType } from '../decorators'
 import { getHookToken, HookTypes } from '../hooks'
 import { PagingStrategies } from '../types'
 import { CRUDAutoResolverOpts } from './resolver.provider'
@@ -11,30 +11,37 @@ export type HookProviderOptions<DTO, C, U> = Pick<
   'DTOClass' | 'CreateDTOClass' | 'UpdateDTOClass'
 >
 
-function createHookProvider(hookType: HookTypes, ...DTOClass: Class<unknown>[]): Provider | undefined {
-  return DTOClass.reduce((p: Provider | undefined, cls) => {
-    if (p) {
+function createHookProvider(hookType: HookTypes, ...DTOClass: Class<unknown>[]): Provider[] | undefined {
+  return DTOClass.reduce((p: Provider[] | undefined, cls) => {
+    if (p && p.length > 0) {
       return p
     }
-    const maybeHook = getHookForType(hookType, cls)
-    if (maybeHook) {
-      return { provide: getHookToken(hookType, cls), useClass: maybeHook }
+    const maybeHooks = getHooksForType(hookType, cls);
+    if (maybeHooks) {
+      return [
+        ...maybeHooks,
+        {
+          provide: getHookToken(hookType, cls),
+          useFactory: (...providers: Provider[]) => providers,
+          inject: maybeHooks,
+        },
+      ]
     }
-    return undefined
-  }, undefined)
+    return []
+  }, [])
 }
 
 function getHookProviders(opts: HookProviderOptions<unknown, unknown, unknown>): Provider[] {
   const { DTOClass, CreateDTOClass = DTOClass, UpdateDTOClass = DTOClass } = opts
   return [
-    createHookProvider(HookTypes.BEFORE_CREATE_ONE, CreateDTOClass, DTOClass),
-    createHookProvider(HookTypes.BEFORE_CREATE_MANY, CreateDTOClass, DTOClass),
-    createHookProvider(HookTypes.BEFORE_UPDATE_ONE, UpdateDTOClass, DTOClass),
-    createHookProvider(HookTypes.BEFORE_UPDATE_MANY, UpdateDTOClass, DTOClass),
-    createHookProvider(HookTypes.BEFORE_DELETE_ONE, DTOClass),
-    createHookProvider(HookTypes.BEFORE_DELETE_MANY, DTOClass),
-    createHookProvider(HookTypes.BEFORE_QUERY_MANY, DTOClass),
-    createHookProvider(HookTypes.BEFORE_FIND_ONE, DTOClass)
+    ...createHookProvider(HookTypes.BEFORE_CREATE_ONE, CreateDTOClass, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_CREATE_MANY, CreateDTOClass, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_UPDATE_ONE, UpdateDTOClass, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_UPDATE_MANY, UpdateDTOClass, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_DELETE_ONE, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_DELETE_MANY, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_QUERY_MANY, DTOClass),
+    ...createHookProvider(HookTypes.BEFORE_FIND_ONE, DTOClass),
   ].filter((p) => !!p)
 }
 


### PR DESCRIPTION
Can be used as
```
 @BeforeCreateOne([
    getStringValidationHook<ITodo>(`name`, { min: 3, max: 10 }),
    getSetUserIdPropertyHook<ITodo>(`todoCreatedBy`),
  ])
  class Todo extends Base implements ITodo {
   ...
   ...

```