### PR TITLE
feat(nestjs-query): make dataLoader configurable

### DIFF
--- a/documentation/docs/graphql/dataloaders.mdx
+++ b/documentation/docs/graphql/dataloaders.mdx
@@ -1,0 +1,35 @@
+---
+title: Dataloaders
+sidebar_label: Dataloaders
+---
+
+Nestjs-query integrates a standard implementation of [dataloaders](https://www.npmjs.com/package/dataloader/v/2.1.0). Dataloaders are there to solve the `n+1`. Sometimes the default implementation can fail, for example when asynchronous [custom authorizers](./authorization.mdx#custom-authorizer) are used and the `n+1` problem occurs again despite using dataloaders. Then it may be useful to configure the default implementation of the dataloader, for example to pass a custom batch scheduler.
+
+The following example demonstrates how to configure the generated dataloaders. For more information about the dataloader configuration, see the [dataloader documentation](https://www.npmjs.com/package/dataloader/v/2.1.0).
+
+```ts title="app.module.ts"
+import { Module } from '@nestjs/common';
+import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql';
+
+@Module({
+  imports: [
+    // ... other imports
+
+    NestjsQueryGraphQLModule.forRoot({
+      dataLoader: {
+        batchScheduleFn(callback) {
+          // Here is an example of a batch scheduler that collects
+          // all requests in a time window of 250ms:
+          setTimeout(callback, 250);
+        },
+      },
+    }),
+
+    // ... other imports
+  ],
+
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
+```

--- a/documentation/docs/graphql/getting-started.md
+++ b/documentation/docs/graphql/getting-started.md
@@ -12,6 +12,7 @@ The `@ptc-org/nestjs-query-graphql` package provided base `Resolvers` and graphq
 
 * [DTOs](./dtos.mdx) - Documentation about the use of DTOs and associated annotations.
 * [Resolvers](./resolvers.mdx) - Documentation about crud resolvers and their usage.
+* [Dataloaders](./dataloaders.mdx) - Documentation about configuring the generated dataloaders.
 * [Queries](./queries.mdx) - Documentation about the provided graphql query endpoints.
 * [Mutations](./mutations.mdx) -  Documentation about the provided graphql mutation endpoints.
 * [Hooks](./hooks.mdx) -  Documentation about hooks (e.g before create one).

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
       'graphql/getting-started',
       'graphql/dtos',
       'graphql/resolvers',
+      'graphql/dataloaders',
       'graphql/queries',
       'graphql/mutations',
       'graphql/paging',

--- a/examples/dataloader-configuration/e2e/fixtures.ts
+++ b/examples/dataloader-configuration/e2e/fixtures.ts
@@ -1,0 +1,47 @@
+import { Connection } from 'typeorm'
+
+import { executeTruncate } from '../../helpers'
+import { SubTaskEntity } from '../src/sub-task/sub-task.entity'
+import { TagEntity } from '../src/tag/tag.entity'
+import { TodoItemEntity } from '../src/todo-item/todo-item.entity'
+
+const tables = ['todo_item', 'sub_task', 'tag']
+export const truncate = async (connection: Connection): Promise<void> => executeTruncate(connection, tables)
+
+export const refresh = async (connection: Connection): Promise<void> => {
+  await truncate(connection)
+
+  const todoRepo = connection.getRepository(TodoItemEntity)
+  const subTaskRepo = connection.getRepository(SubTaskEntity)
+  const tagsRepo = connection.getRepository(TagEntity)
+
+  const urgentTag = await tagsRepo.save({ name: 'Urgent' })
+  const homeTag = await tagsRepo.save({ name: 'Home' })
+  const workTag = await tagsRepo.save({ name: 'Work' })
+  const questionTag = await tagsRepo.save({ name: 'Question' })
+  const blockedTag = await tagsRepo.save({ name: 'Blocked' })
+
+  const todoItems = await todoRepo.save([
+    { title: 'Create Nest App', completed: true, tags: [urgentTag, homeTag] },
+    { title: 'Create Entity', completed: false, tags: [urgentTag, workTag] },
+    { title: 'Create Entity Service', completed: false, tags: [blockedTag, workTag] },
+    { title: 'Add Todo Item Resolver', completed: false, tags: [blockedTag, homeTag] },
+    {
+      title: 'How to create item With Sub Tasks',
+      completed: false,
+      tags: [questionTag, blockedTag]
+    }
+  ])
+
+  await subTaskRepo.save(
+    todoItems.reduce(
+      (subTasks, todo) => [
+        ...subTasks,
+        { completed: true, title: `${todo.title} - Sub Task 1`, todoItem: todo },
+        { completed: false, title: `${todo.title} - Sub Task 2`, todoItem: todo },
+        { completed: false, title: `${todo.title} - Sub Task 3`, todoItem: todo }
+      ],
+      [] as Partial<SubTaskEntity>[]
+    )
+  )
+}

--- a/examples/dataloader-configuration/e2e/graphql-fragments.ts
+++ b/examples/dataloader-configuration/e2e/graphql-fragments.ts
@@ -1,0 +1,46 @@
+export const pageInfoField = `
+  pageInfo {
+    hasNextPage
+    hasPreviousPage
+    startCursor
+    endCursor
+  }
+`
+
+export const edgeNodes = (fields: string): string => `
+  edges {
+    node{
+      ${fields}    
+    }
+
+    cursor
+  }  
+`
+
+export const subTaskFields = `
+  id
+  title
+  description
+  completed
+  todoItemId
+`
+
+export const todoItemFields = `
+  id
+  title
+  isCompleted
+  description
+
+  subTasks {
+    ${subTaskFields}
+  }
+`
+
+export const tagFields = `
+  id
+  name
+
+  todoItems {
+    ${todoItemFields}
+  }
+`

--- a/examples/dataloader-configuration/e2e/tag.resolver.spec.ts
+++ b/examples/dataloader-configuration/e2e/tag.resolver.spec.ts
@@ -1,0 +1,92 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { CursorConnectionType } from '@ptc-org/nestjs-query-graphql'
+import request from 'supertest'
+import { Connection } from 'typeorm'
+
+import { refresh } from '../e2e/fixtures'
+import { AppModule } from '../src/app.module'
+import { batchScheduleFn } from '../src/batch-schedule-fn'
+import { TagDTO } from '../src/tag/dto/tag.dto'
+import { edgeNodes, pageInfoField, tagFields } from './graphql-fragments'
+
+jest.mock('../src/batch-schedule-fn', () => ({
+  batchScheduleFn: jest.fn((callback: () => void) => {
+    return setTimeout(callback, 250)
+  })
+}))
+
+describe('TagResolver (dataloader-configuration - e2e)', () => {
+  let app: INestApplication
+  const batchScheduleFnMock = batchScheduleFn as jest.Mock
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        skipMissingProperties: false,
+        forbidUnknownValues: true
+      })
+    )
+
+    await app.init()
+    await refresh(app.get(Connection))
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  const tags = [
+    { id: '1', name: 'Urgent' },
+    { id: '2', name: 'Home' },
+    { id: '3', name: 'Work' },
+    { id: '4', name: 'Question' },
+    { id: '5', name: 'Blocked' }
+  ]
+
+  describe('query', () => {
+    it(`should return a connection`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{
+            tags {
+              ${pageInfoField}
+              ${edgeNodes(tagFields)}
+            }
+          }`
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges }: CursorConnectionType<TagDTO> = body.data.tags
+
+          const receivedTagIds = edges.map((e) => e.node.id)
+          const receivedTodoItemIds = [...new Set(edges.flatMap((e) => e.node.todoItems).map((e) => e.id))]
+          const receivedSubTaskIds = [
+            ...new Set(
+              edges
+                .flatMap((e) => e.node.todoItems)
+                .flatMap((e) => e.subTasks)
+                .map((e) => e.id)
+            )
+          ]
+
+          expect(edges).toHaveLength(5)
+          expect(receivedTagIds).toEqual(tags.map((t) => t.id))
+          expect(receivedTodoItemIds).toHaveLength(5)
+          expect(receivedSubTaskIds).toHaveLength(15)
+
+          expect(batchScheduleFnMock).toHaveBeenCalled()
+        }))
+  })
+})

--- a/examples/dataloader-configuration/schema.gql
+++ b/examples/dataloader-configuration/schema.gql
@@ -1,0 +1,676 @@
+# ------------------------------------------------------
+# THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+# ------------------------------------------------------
+
+type Tag {
+  id: ID!
+  name: String!
+  created: DateTime!
+  updated: DateTime!
+  todoItems(
+    """Specify to filter the records returned."""
+    filter: TodoItemFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [TodoItemSort!]! = []
+  ): [TodoItem!]!
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+input TodoItemFilter {
+  and: [TodoItemFilter!]
+  or: [TodoItemFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}
+
+input IDFilterComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: ID
+  neq: ID
+  gt: ID
+  gte: ID
+  lt: ID
+  lte: ID
+  like: ID
+  notLike: ID
+  iLike: ID
+  notILike: ID
+  in: [ID!]
+  notIn: [ID!]
+}
+
+input StringFieldComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: String
+  neq: String
+  gt: String
+  gte: String
+  lt: String
+  lte: String
+  like: String
+  notLike: String
+  iLike: String
+  notILike: String
+  in: [String!]
+  notIn: [String!]
+}
+
+input BooleanFieldComparison {
+  is: Boolean
+  isNot: Boolean
+}
+
+input DateFieldComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: DateTime
+  neq: DateTime
+  gt: DateTime
+  gte: DateTime
+  lt: DateTime
+  lte: DateTime
+  in: [DateTime!]
+  notIn: [DateTime!]
+  between: DateFieldComparisonBetween
+  notBetween: DateFieldComparisonBetween
+}
+
+input DateFieldComparisonBetween {
+  lower: DateTime!
+  upper: DateTime!
+}
+
+input TodoItemSort {
+  field: TodoItemSortFields!
+  direction: SortDirection!
+  nulls: SortNulls
+}
+
+enum TodoItemSortFields {
+  id
+  title
+  description
+  completed
+  created
+  updated
+}
+
+"""Sort Directions"""
+enum SortDirection {
+  ASC
+  DESC
+}
+
+"""Sort Nulls Options"""
+enum SortNulls {
+  NULLS_FIRST
+  NULLS_LAST
+}
+
+type TodoItem {
+  id: ID!
+  title: String!
+  description: String
+  isCompleted: Boolean!
+  subTasks(
+    """Specify to filter the records returned."""
+    filter: SubTaskFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [SubTaskSort!]! = []
+  ): [SubTask!]!
+  tags(
+    """Specify to filter the records returned."""
+    filter: TagFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [TagSort!]! = []
+  ): [Tag!]!
+}
+
+input SubTaskFilter {
+  and: [SubTaskFilter!]
+  or: [SubTaskFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+  todoItemId: StringFieldComparison
+}
+
+input SubTaskSort {
+  field: SubTaskSortFields!
+  direction: SortDirection!
+  nulls: SortNulls
+}
+
+enum SubTaskSortFields {
+  id
+  title
+  description
+  completed
+  created
+  updated
+  todoItemId
+}
+
+input TagFilter {
+  and: [TagFilter!]
+  or: [TagFilter!]
+  id: IDFilterComparison
+  name: StringFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}
+
+input TagSort {
+  field: TagSortFields!
+  direction: SortDirection!
+  nulls: SortNulls
+}
+
+enum TagSortFields {
+  id
+  name
+  created
+  updated
+}
+
+type SubTask {
+  id: ID!
+  title: String!
+  description: String
+  completed: Boolean!
+  created: DateTime!
+  updated: DateTime!
+  todoItemId: String!
+  todoItems(
+    """Specify to filter the records returned."""
+    filter: TodoItemFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [TodoItemSort!]! = []
+  ): [TodoItem!]!
+}
+
+type DeleteManyResponse {
+  """The number of records deleted."""
+  deletedCount: Int!
+}
+
+type SubTaskDeleteResponse {
+  id: ID
+  title: String
+  description: String
+  completed: Boolean
+  created: DateTime
+  updated: DateTime
+  todoItemId: String
+}
+
+type UpdateManyResponse {
+  """The number of records updated."""
+  updatedCount: Int!
+}
+
+type SubTaskEdge {
+  """The node containing the SubTask"""
+  node: SubTask!
+
+  """Cursor for this node."""
+  cursor: ConnectionCursor!
+}
+
+"""Cursor for paging through collections"""
+scalar ConnectionCursor
+
+type PageInfo {
+  """true if paging forward and there are more records."""
+  hasNextPage: Boolean
+
+  """true if paging backwards and there are more records."""
+  hasPreviousPage: Boolean
+
+  """The cursor of the first returned record."""
+  startCursor: ConnectionCursor
+
+  """The cursor of the last returned record."""
+  endCursor: ConnectionCursor
+}
+
+type SubTaskConnection {
+  """Paging information"""
+  pageInfo: PageInfo!
+
+  """Array of edges."""
+  edges: [SubTaskEdge!]!
+}
+
+type TagDeleteResponse {
+  id: ID
+  name: String
+  created: DateTime
+  updated: DateTime
+}
+
+type TagEdge {
+  """The node containing the Tag"""
+  node: Tag!
+
+  """Cursor for this node."""
+  cursor: ConnectionCursor!
+}
+
+type TagConnection {
+  """Paging information"""
+  pageInfo: PageInfo!
+
+  """Array of edges."""
+  edges: [TagEdge!]!
+}
+
+type TodoItemDeleteResponse {
+  id: ID
+  title: String
+  description: String
+  isCompleted: Boolean
+}
+
+type TodoItemEdge {
+  """The node containing the TodoItem"""
+  node: TodoItem!
+
+  """Cursor for this node."""
+  cursor: ConnectionCursor!
+}
+
+type TodoItemConnection {
+  """Paging information"""
+  pageInfo: PageInfo!
+
+  """Array of edges."""
+  edges: [TodoItemEdge!]!
+}
+
+type Query {
+  subTask(
+    """The id of the record to find."""
+    id: ID!
+  ): SubTask!
+  subTasks(
+    """Limit or page results."""
+    paging: CursorPaging! = {first: 10}
+
+    """Specify to filter the records returned."""
+    filter: SubTaskFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [SubTaskSort!]! = []
+  ): SubTaskConnection!
+  todoItem(
+    """The id of the record to find."""
+    id: ID!
+  ): TodoItem!
+  todoItems(
+    """Limit or page results."""
+    paging: CursorPaging! = {first: 10}
+
+    """Specify to filter the records returned."""
+    filter: TodoItemFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [TodoItemSort!]! = []
+  ): TodoItemConnection!
+  tag(
+    """The id of the record to find."""
+    id: ID!
+  ): Tag!
+  tags(
+    """Limit or page results."""
+    paging: CursorPaging! = {first: 10}
+
+    """Specify to filter the records returned."""
+    filter: TagFilter! = {}
+
+    """Specify to sort results."""
+    sorting: [TagSort!]! = []
+  ): TagConnection!
+}
+
+input CursorPaging {
+  """Paginate before opaque cursor"""
+  before: ConnectionCursor
+
+  """Paginate after opaque cursor"""
+  after: ConnectionCursor
+
+  """Paginate first"""
+  first: Int
+
+  """Paginate last"""
+  last: Int
+}
+
+type Mutation {
+  addTodoItemsToSubTask(input: AddTodoItemsToSubTaskInput!): SubTask!
+  setTodoItemsOnSubTask(input: SetTodoItemsOnSubTaskInput!): SubTask!
+  createOneSubTask(input: CreateOneSubTaskInput!): SubTask!
+  createManySubTasks(input: CreateManySubTasksInput!): [SubTask!]!
+  updateOneSubTask(input: UpdateOneSubTaskInput!): SubTask!
+  updateManySubTasks(input: UpdateManySubTasksInput!): UpdateManyResponse!
+  deleteOneSubTask(input: DeleteOneSubTaskInput!): SubTaskDeleteResponse!
+  deleteManySubTasks(input: DeleteManySubTasksInput!): DeleteManyResponse!
+  addSubTasksToTodoItem(input: AddSubTasksToTodoItemInput!): TodoItem!
+  setSubTasksOnTodoItem(input: SetSubTasksOnTodoItemInput!): TodoItem!
+  addTagsToTodoItem(input: AddTagsToTodoItemInput!): TodoItem!
+  setTagsOnTodoItem(input: SetTagsOnTodoItemInput!): TodoItem!
+  removeTagsFromTodoItem(input: RemoveTagsFromTodoItemInput!): TodoItem!
+  createOneTodoItem(input: CreateOneTodoItemInput!): TodoItem!
+  createManyTodoItems(input: CreateManyTodoItemsInput!): [TodoItem!]!
+  updateOneTodoItem(input: UpdateOneTodoItemInput!): TodoItem!
+  updateManyTodoItems(input: UpdateManyTodoItemsInput!): UpdateManyResponse!
+  deleteOneTodoItem(input: DeleteOneTodoItemInput!): TodoItemDeleteResponse!
+  deleteManyTodoItems(input: DeleteManyTodoItemsInput!): DeleteManyResponse!
+  addTodoItemsToTag(input: AddTodoItemsToTagInput!): Tag!
+  setTodoItemsOnTag(input: SetTodoItemsOnTagInput!): Tag!
+  removeTodoItemsFromTag(input: RemoveTodoItemsFromTagInput!): Tag!
+  createOneTag(input: CreateOneTagInput!): Tag!
+  createManyTags(input: CreateManyTagsInput!): [Tag!]!
+  updateOneTag(input: UpdateOneTagInput!): Tag!
+  updateManyTags(input: UpdateManyTagsInput!): UpdateManyResponse!
+  deleteOneTag(input: DeleteOneTagInput!): TagDeleteResponse!
+  deleteManyTags(input: DeleteManyTagsInput!): DeleteManyResponse!
+}
+
+input AddTodoItemsToSubTaskInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input SetTodoItemsOnSubTaskInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input CreateOneSubTaskInput {
+  """The record to create"""
+  subTask: SubTaskInput!
+}
+
+input SubTaskInput {
+  title: String!
+  description: String
+  completed: Boolean!
+  todoItemId: ID!
+}
+
+input CreateManySubTasksInput {
+  """Array of records to create"""
+  subTasks: [SubTaskInput!]!
+}
+
+input UpdateOneSubTaskInput {
+  """The id of the record to update"""
+  id: ID!
+
+  """The update to apply."""
+  update: SubTaskUpdate!
+}
+
+input SubTaskUpdate {
+  title: String!
+  description: String
+  completed: Boolean
+  todoItemId: String
+}
+
+input UpdateManySubTasksInput {
+  """Filter used to find fields to update"""
+  filter: SubTaskUpdateFilter!
+
+  """The update to apply to all records found using the filter"""
+  update: SubTaskUpdate!
+}
+
+input SubTaskUpdateFilter {
+  and: [SubTaskUpdateFilter!]
+  or: [SubTaskUpdateFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+  todoItemId: StringFieldComparison
+}
+
+input DeleteOneSubTaskInput {
+  """The id of the record to delete."""
+  id: ID!
+}
+
+input DeleteManySubTasksInput {
+  """Filter to find records to delete"""
+  filter: SubTaskDeleteFilter!
+}
+
+input SubTaskDeleteFilter {
+  and: [SubTaskDeleteFilter!]
+  or: [SubTaskDeleteFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+  todoItemId: StringFieldComparison
+}
+
+input AddSubTasksToTodoItemInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input SetSubTasksOnTodoItemInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input AddTagsToTodoItemInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input SetTagsOnTodoItemInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input RemoveTagsFromTodoItemInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input CreateOneTodoItemInput {
+  """The record to create"""
+  todoItem: TodoItemInput!
+}
+
+input TodoItemInput {
+  title: String!
+  completed: Boolean!
+}
+
+input CreateManyTodoItemsInput {
+  """Array of records to create"""
+  todoItems: [TodoItemInput!]!
+}
+
+input UpdateOneTodoItemInput {
+  """The id of the record to update"""
+  id: ID!
+
+  """The update to apply."""
+  update: TodoItemUpdate!
+}
+
+input TodoItemUpdate {
+  title: String
+  completed: Boolean
+}
+
+input UpdateManyTodoItemsInput {
+  """Filter used to find fields to update"""
+  filter: TodoItemUpdateFilter!
+
+  """The update to apply to all records found using the filter"""
+  update: TodoItemUpdate!
+}
+
+input TodoItemUpdateFilter {
+  and: [TodoItemUpdateFilter!]
+  or: [TodoItemUpdateFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}
+
+input DeleteOneTodoItemInput {
+  """The id of the record to delete."""
+  id: ID!
+}
+
+input DeleteManyTodoItemsInput {
+  """Filter to find records to delete"""
+  filter: TodoItemDeleteFilter!
+}
+
+input TodoItemDeleteFilter {
+  and: [TodoItemDeleteFilter!]
+  or: [TodoItemDeleteFilter!]
+  id: IDFilterComparison
+  title: StringFieldComparison
+  description: StringFieldComparison
+  completed: BooleanFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}
+
+input AddTodoItemsToTagInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input SetTodoItemsOnTagInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input RemoveTodoItemsFromTagInput {
+  """The id of the record."""
+  id: ID!
+
+  """The ids of the relations."""
+  relationIds: [ID!]!
+}
+
+input CreateOneTagInput {
+  """The record to create"""
+  tag: TagInput!
+}
+
+input TagInput {
+  name: String!
+}
+
+input CreateManyTagsInput {
+  """Array of records to create"""
+  tags: [TagInput!]!
+}
+
+input UpdateOneTagInput {
+  """The id of the record to update"""
+  id: ID!
+
+  """The update to apply."""
+  update: TagInput!
+}
+
+input UpdateManyTagsInput {
+  """Filter used to find fields to update"""
+  filter: TagUpdateFilter!
+
+  """The update to apply to all records found using the filter"""
+  update: TagInput!
+}
+
+input TagUpdateFilter {
+  and: [TagUpdateFilter!]
+  or: [TagUpdateFilter!]
+  id: IDFilterComparison
+  name: StringFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}
+
+input DeleteOneTagInput {
+  """The id of the record to delete."""
+  id: ID!
+}
+
+input DeleteManyTagsInput {
+  """Filter to find records to delete"""
+  filter: TagDeleteFilter!
+}
+
+input TagDeleteFilter {
+  and: [TagDeleteFilter!]
+  or: [TagDeleteFilter!]
+  id: IDFilterComparison
+  name: StringFieldComparison
+  created: DateFieldComparison
+  updated: DateFieldComparison
+}

--- a/examples/dataloader-configuration/src/app.module.ts
+++ b/examples/dataloader-configuration/src/app.module.ts
@@ -1,0 +1,34 @@
+import { ApolloDriver } from '@nestjs/apollo'
+import { Module } from '@nestjs/common'
+import { GraphQLModule } from '@nestjs/graphql'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql'
+
+import { formatGraphqlError, typeormOrmConfig } from '../../helpers'
+import { SubTaskModule } from '../src/sub-task/sub-task.module'
+import { TagModule } from '../src/tag/tag.module'
+import { TodoItemModule } from '../src/todo-item/todo-item.module'
+import { batchScheduleFn } from './batch-schedule-fn'
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot(typeormOrmConfig('dataloader_configuration')),
+
+    GraphQLModule.forRoot({
+      driver: ApolloDriver,
+      autoSchemaFile: 'examples/dataloader-configuration/schema.gql',
+      formatError: formatGraphqlError
+    }),
+
+    NestjsQueryGraphQLModule.forRoot({
+      dataLoader: {
+        batchScheduleFn
+      }
+    }),
+
+    SubTaskModule,
+    TodoItemModule,
+    TagModule
+  ]
+})
+export class AppModule {}

--- a/examples/dataloader-configuration/src/batch-schedule-fn.ts
+++ b/examples/dataloader-configuration/src/batch-schedule-fn.ts
@@ -1,0 +1,3 @@
+export function batchScheduleFn(callback: () => void) {
+  return setTimeout(callback, 250)
+}

--- a/examples/dataloader-configuration/src/main.ts
+++ b/examples/dataloader-configuration/src/main.ts
@@ -1,0 +1,23 @@
+import { ValidationPipe } from '@nestjs/common'
+import { NestFactory } from '@nestjs/core'
+
+import { AppModule } from './app.module'
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule)
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      skipMissingProperties: false,
+      forbidUnknownValues: true
+    })
+  )
+
+  await app.listen(3000)
+}
+
+// eslint-disable-next-line no-void
+void bootstrap()

--- a/examples/dataloader-configuration/src/sub-task/dto/sub-task.dto.ts
+++ b/examples/dataloader-configuration/src/sub-task/dto/sub-task.dto.ts
@@ -1,0 +1,31 @@
+import { GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
+import { FilterableField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql'
+
+import { TodoItemDTO } from '../../todo-item/dto/todo-item.dto'
+
+@ObjectType('SubTask')
+@UnPagedRelation('todoItem', () => TodoItemDTO, {
+  update: { enabled: true }
+})
+export class SubTaskDTO {
+  @FilterableField(() => ID)
+  id!: number
+
+  @FilterableField()
+  title!: string
+
+  @FilterableField({ nullable: true })
+  description?: string
+
+  @FilterableField()
+  completed!: boolean
+
+  @FilterableField(() => GraphQLISODateTime)
+  created!: Date
+
+  @FilterableField(() => GraphQLISODateTime)
+  updated!: Date
+
+  @FilterableField()
+  todoItemId!: string
+}

--- a/examples/dataloader-configuration/src/sub-task/dto/subtask-input.dto.ts
+++ b/examples/dataloader-configuration/src/sub-task/dto/subtask-input.dto.ts
@@ -1,0 +1,24 @@
+import { Field, ID, InputType } from '@nestjs/graphql'
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+
+@InputType('SubTaskInput')
+export class CreateSubTaskDTO {
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  title!: string
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string
+
+  @Field()
+  @IsBoolean()
+  completed!: boolean
+
+  @Field(() => ID)
+  @IsNotEmpty()
+  todoItemId!: string
+}

--- a/examples/dataloader-configuration/src/sub-task/dto/subtask-update.dto.ts
+++ b/examples/dataloader-configuration/src/sub-task/dto/subtask-update.dto.ts
@@ -1,0 +1,27 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+
+@InputType('SubTaskUpdate')
+export class SubTaskUpdateDTO {
+  @Field()
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  title?: string
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  description?: string
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsBoolean()
+  completed?: boolean
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsNotEmpty()
+  todoItemId?: string
+}

--- a/examples/dataloader-configuration/src/sub-task/sub-task.entity.ts
+++ b/examples/dataloader-configuration/src/sub-task/sub-task.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  ObjectType,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm'
+
+import { TodoItemEntity } from '../todo-item/todo-item.entity'
+
+@Entity({ name: 'sub_task' })
+export class SubTaskEntity {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column()
+  title!: string
+
+  @Column({ nullable: true })
+  description?: string
+
+  @Column()
+  completed!: boolean
+
+  @Column({ nullable: false, name: 'todo_item_id' })
+  todoItemId!: string
+
+  @ManyToOne((): ObjectType<TodoItemEntity> => TodoItemEntity, (td) => td.subTasks, {
+    onDelete: 'CASCADE',
+    nullable: false
+  })
+  @JoinColumn({ name: 'todo_item_id' })
+  todoItem!: TodoItemEntity
+
+  @CreateDateColumn()
+  created!: Date
+
+  @UpdateDateColumn()
+  updated!: Date
+}

--- a/examples/dataloader-configuration/src/sub-task/sub-task.module.ts
+++ b/examples/dataloader-configuration/src/sub-task/sub-task.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common'
+import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql'
+import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm'
+
+import { SubTaskDTO } from './dto/sub-task.dto'
+import { CreateSubTaskDTO } from './dto/subtask-input.dto'
+import { SubTaskUpdateDTO } from './dto/subtask-update.dto'
+import { SubTaskEntity } from './sub-task.entity'
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([SubTaskEntity])],
+      resolvers: [
+        {
+          DTOClass: SubTaskDTO,
+          EntityClass: SubTaskEntity,
+          CreateDTOClass: CreateSubTaskDTO,
+          UpdateDTOClass: SubTaskUpdateDTO
+        }
+      ]
+    })
+  ]
+})
+export class SubTaskModule {}

--- a/examples/dataloader-configuration/src/tag/dto/tag-input.dto.ts
+++ b/examples/dataloader-configuration/src/tag/dto/tag-input.dto.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsNotEmpty, IsString } from 'class-validator'
+
+@InputType('TagInput')
+export class TagInputDTO {
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  name!: string
+}

--- a/examples/dataloader-configuration/src/tag/dto/tag.dto.ts
+++ b/examples/dataloader-configuration/src/tag/dto/tag.dto.ts
@@ -1,0 +1,25 @@
+import { GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
+import { FilterableField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql'
+
+import { TodoItemDTO } from '../../todo-item/dto/todo-item.dto'
+
+@ObjectType('Tag')
+@UnPagedRelation('todoItems', () => TodoItemDTO, {
+  update: { enabled: true },
+  remove: { enabled: true }
+})
+export class TagDTO {
+  @FilterableField(() => ID)
+  id!: number
+
+  @FilterableField()
+  name!: string
+
+  @FilterableField(() => GraphQLISODateTime)
+  created!: Date
+
+  @FilterableField(() => GraphQLISODateTime)
+  updated!: Date
+
+  todoItems!: TodoItemDTO[]
+}

--- a/examples/dataloader-configuration/src/tag/tag.entity.ts
+++ b/examples/dataloader-configuration/src/tag/tag.entity.ts
@@ -1,0 +1,21 @@
+import { Column, CreateDateColumn, Entity, ManyToMany, ObjectType, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+import { TodoItemEntity } from '../todo-item/todo-item.entity'
+
+@Entity({ name: 'tag' })
+export class TagEntity {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column()
+  name!: string
+
+  @CreateDateColumn()
+  created!: Date
+
+  @UpdateDateColumn()
+  updated!: Date
+
+  @ManyToMany((): ObjectType<TodoItemEntity> => TodoItemEntity, (td) => td.tags)
+  todoItems!: TodoItemEntity[]
+}

--- a/examples/dataloader-configuration/src/tag/tag.module.ts
+++ b/examples/dataloader-configuration/src/tag/tag.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common'
+import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql'
+import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm'
+
+import { TagDTO } from './dto/tag.dto'
+import { TagInputDTO } from './dto/tag-input.dto'
+import { TagEntity } from './tag.entity'
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([TagEntity])],
+      resolvers: [
+        {
+          DTOClass: TagDTO,
+          EntityClass: TagEntity,
+          CreateDTOClass: TagInputDTO,
+          UpdateDTOClass: TagInputDTO
+        }
+      ]
+    })
+  ]
+})
+export class TagModule {}

--- a/examples/dataloader-configuration/src/todo-item/dto/todo-item-input.dto.ts
+++ b/examples/dataloader-configuration/src/todo-item/dto/todo-item-input.dto.ts
@@ -1,0 +1,14 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsBoolean, IsString, MaxLength } from 'class-validator'
+
+@InputType('TodoItemInput')
+export class TodoItemInputDTO {
+  @IsString()
+  @MaxLength(20)
+  @Field()
+  title!: string
+
+  @IsBoolean()
+  @Field()
+  completed!: boolean
+}

--- a/examples/dataloader-configuration/src/todo-item/dto/todo-item-update.dto.ts
+++ b/examples/dataloader-configuration/src/todo-item/dto/todo-item-update.dto.ts
@@ -1,0 +1,16 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator'
+
+@InputType('TodoItemUpdate')
+export class TodoItemUpdateDTO {
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  @Field({ nullable: true })
+  title?: string
+
+  @IsOptional()
+  @IsBoolean()
+  @Field({ nullable: true })
+  completed?: boolean
+}

--- a/examples/dataloader-configuration/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/dataloader-configuration/src/todo-item/dto/todo-item.dto.ts
@@ -1,0 +1,37 @@
+import { GraphQLISODateTime, ID, ObjectType } from '@nestjs/graphql'
+import { FilterableField, UnPagedRelation } from '@ptc-org/nestjs-query-graphql'
+
+import { SubTaskDTO } from '../../sub-task/dto/sub-task.dto'
+import { TagDTO } from '../../tag/dto/tag.dto'
+
+@ObjectType('TodoItem')
+@UnPagedRelation('subTasks', () => SubTaskDTO, {
+  update: { enabled: true }
+})
+@UnPagedRelation('tags', () => TagDTO, {
+  update: { enabled: true },
+  remove: { enabled: true }
+})
+export class TodoItemDTO {
+  @FilterableField(() => ID)
+  id!: number
+
+  @FilterableField()
+  title!: string
+
+  @FilterableField({ nullable: true })
+  description?: string
+
+  @FilterableField({
+    name: 'isCompleted'
+  })
+  completed!: boolean
+
+  @FilterableField(() => GraphQLISODateTime, { filterOnly: true })
+  created!: Date
+
+  @FilterableField(() => GraphQLISODateTime, { filterOnly: true })
+  updated!: Date
+
+  subTasks!: SubTaskDTO[]
+}

--- a/examples/dataloader-configuration/src/todo-item/todo-item.entity.ts
+++ b/examples/dataloader-configuration/src/todo-item/todo-item.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm'
+
+import { SubTaskEntity } from '../sub-task/sub-task.entity'
+import { TagEntity } from '../tag/tag.entity'
+
+@Entity({ name: 'todo_item' })
+export class TodoItemEntity {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column()
+  title!: string
+
+  @Column({ nullable: true })
+  description?: string
+
+  @Column()
+  completed!: boolean
+
+  @OneToMany(() => SubTaskEntity, (subTask) => subTask.todoItem)
+  subTasks!: SubTaskEntity[]
+
+  @CreateDateColumn()
+  created!: Date
+
+  @UpdateDateColumn()
+  updated!: Date
+
+  @ManyToMany(() => TagEntity, (tag) => tag.todoItems)
+  @JoinTable()
+  tags!: TagEntity[]
+}

--- a/examples/dataloader-configuration/src/todo-item/todo-item.module.ts
+++ b/examples/dataloader-configuration/src/todo-item/todo-item.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common'
+import { NestjsQueryGraphQLModule } from '@ptc-org/nestjs-query-graphql'
+import { NestjsQueryTypeOrmModule } from '@ptc-org/nestjs-query-typeorm'
+
+import { TodoItemDTO } from './dto/todo-item.dto'
+import { TodoItemInputDTO } from './dto/todo-item-input.dto'
+import { TodoItemUpdateDTO } from './dto/todo-item-update.dto'
+import { TodoItemEntity } from './todo-item.entity'
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([TodoItemEntity])],
+      resolvers: [
+        {
+          DTOClass: TodoItemDTO,
+          EntityClass: TodoItemEntity,
+          CreateDTOClass: TodoItemInputDTO,
+          UpdateDTOClass: TodoItemUpdateDTO
+        }
+      ]
+    })
+  ]
+})
+export class TodoItemModule {}

--- a/examples/init-scripts/mysql/init-dataloader-configuration.sql
+++ b/examples/init-scripts/mysql/init-dataloader-configuration.sql
@@ -1,0 +1,5 @@
+CREATE
+USER dataloader_configuration;
+CREATE
+DATABASE dataloader_configuration;
+GRANT ALL PRIVILEGES ON dataloader_configuration.* TO dataloader_configuration;

--- a/examples/init-scripts/postgres/init-dataloader-configuration.sql
+++ b/examples/init-scripts/postgres/init-dataloader-configuration.sql
@@ -1,0 +1,6 @@
+CREATE
+USER dataloader_configuration WITH SUPERUSER;
+CREATE
+DATABASE dataloader_configuration;
+GRANT ALL PRIVILEGES ON DATABASE
+dataloader_configuration TO dataloader_configuration;

--- a/packages/query-graphql/__tests__/loaders/dataloader.factory.spec.ts
+++ b/packages/query-graphql/__tests__/loaders/dataloader.factory.spec.ts
@@ -6,19 +6,18 @@ import { DataLoaderFactory } from '../../src/loader'
 describe('DataLoaderFactory', () => {
   describe('getOrCreateLoader', () => {
     const createContext = (): ExecutionContext => ({} as unknown as ExecutionContext)
-
     const dataloadFn = (args: ReadonlyArray<string>): Promise<string[]> => Promise.resolve([...args])
 
     it('should create a dataloader and add it to the context', () => {
       const context = createContext()
-      const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', dataloadFn)
+      const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
       expect(loader).toBeInstanceOf(DataLoader)
     })
 
     it('should return the same dataloader if called twice', () => {
       const context = createContext()
-      const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', dataloadFn)
-      const loader2 = DataLoaderFactory.getOrCreateLoader(context, 'loader', dataloadFn)
+      const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
+      const loader2 = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
       expect(loader).toBe(loader2)
     })
   })

--- a/packages/query-graphql/__tests__/loaders/dataloader.factory.spec.ts
+++ b/packages/query-graphql/__tests__/loaders/dataloader.factory.spec.ts
@@ -3,7 +3,15 @@ import DataLoader from 'dataloader'
 
 import { DataLoaderFactory } from '../../src/loader'
 
+jest.mock('dataloader')
+
 describe('DataLoaderFactory', () => {
+  const DataLoaderMock = DataLoader as jest.MockedClass<typeof DataLoader>
+
+  beforeEach(() => {
+    DataLoaderMock.mockClear()
+  })
+
   describe('getOrCreateLoader', () => {
     const createContext = (): ExecutionContext => ({} as unknown as ExecutionContext)
     const dataloadFn = (args: ReadonlyArray<string>): Promise<string[]> => Promise.resolve([...args])
@@ -11,7 +19,7 @@ describe('DataLoaderFactory', () => {
     it('should create a dataloader and add it to the context', () => {
       const context = createContext()
       const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
-      expect(loader).toBeInstanceOf(DataLoader)
+      expect(loader).toBeInstanceOf(DataLoaderMock)
     })
 
     it('should return the same dataloader if called twice', () => {
@@ -19,6 +27,16 @@ describe('DataLoaderFactory', () => {
       const loader = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
       const loader2 = DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn)
       expect(loader).toBe(loader2)
+    })
+
+    it('should override the default dataloader implementation if a custom one is provided', () => {
+      const context = createContext()
+      const batchScheduleFn = jest.fn()
+
+      DataLoaderFactory.getOrCreateLoader(context, 'loader', () => dataloadFn, { batchScheduleFn })
+
+      expect(DataLoaderMock).toHaveBeenCalledTimes(1)
+      expect(DataLoaderMock).toHaveBeenCalledWith(dataloadFn, expect.objectContaining({ batchScheduleFn }))
     })
   })
 })

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -1,4 +1,4 @@
-import { Field, FieldOptions, ReturnTypeFunc } from '@nestjs/graphql'
+import { Field, FieldOptions, ReturnTypeFunc, ReturnTypeFuncValue } from '@nestjs/graphql'
 import { ArrayReflector, Class, FilterComparisonOperators, getPrototypeChain } from '@ptc-org/nestjs-query-core'
 
 import { FILTERABLE_FIELD_KEY } from './constants'
@@ -13,7 +13,7 @@ export type FilterableFieldOptions = {
 export interface FilterableFieldDescriptor {
   propertyName: string
   target: Class<unknown>
-  returnTypeFunc?: ReturnTypeFunc
+  returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
   advancedOptions?: FilterableFieldOptions
 }
 

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -1,4 +1,4 @@
-import { Field, FieldOptions, ReturnTypeFunc, ReturnTypeFuncValue } from '@nestjs/graphql'
+import { Field, FieldOptions, ReturnTypeFunc } from '@nestjs/graphql'
 import { ArrayReflector, Class, FilterComparisonOperators, getPrototypeChain } from '@ptc-org/nestjs-query-core'
 
 import { FILTERABLE_FIELD_KEY } from './constants'
@@ -13,7 +13,7 @@ export type FilterableFieldOptions = {
 export interface FilterableFieldDescriptor {
   propertyName: string
   target: Class<unknown>
-  returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
+  returnTypeFunc?: ReturnTypeFunc
   advancedOptions?: FilterableFieldOptions
 }
 

--- a/packages/query-graphql/src/decorators/id-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/id-field.decorator.ts
@@ -1,4 +1,4 @@
-import { Field, FieldOptions, ReturnTypeFunc } from '@nestjs/graphql'
+import { Field, FieldOptions, ReturnTypeFunc, ReturnTypeFuncValue } from '@nestjs/graphql'
 import { Class, MetaValue, ValueReflector } from '@ptc-org/nestjs-query-core'
 
 import { ID_FIELD_KEY } from './constants'
@@ -12,7 +12,7 @@ export type IDFieldOptions = FilterableFieldOptions | NoFilterIDFieldOptions
 
 export interface IDFieldDescriptor {
   propertyName: string
-  returnTypeFunc: ReturnTypeFunc
+  returnTypeFunc: ReturnTypeFunc<ReturnTypeFuncValue>
 }
 
 /**

--- a/packages/query-graphql/src/decorators/id-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/id-field.decorator.ts
@@ -1,4 +1,4 @@
-import { Field, FieldOptions, ReturnTypeFunc, ReturnTypeFuncValue } from '@nestjs/graphql'
+import { Field, FieldOptions, ReturnTypeFunc } from '@nestjs/graphql'
 import { Class, MetaValue, ValueReflector } from '@ptc-org/nestjs-query-core'
 
 import { ID_FIELD_KEY } from './constants'
@@ -12,7 +12,7 @@ export type IDFieldOptions = FilterableFieldOptions | NoFilterIDFieldOptions
 
 export interface IDFieldDescriptor {
   propertyName: string
-  returnTypeFunc: ReturnTypeFunc<ReturnTypeFuncValue>
+  returnTypeFunc: ReturnTypeFunc
 }
 
 /**

--- a/packages/query-graphql/src/decorators/inject-dataloader-config.decorator.ts
+++ b/packages/query-graphql/src/decorators/inject-dataloader-config.decorator.ts
@@ -1,0 +1,5 @@
+import { createParamDecorator } from '@nestjs/common'
+
+import { InjectDataLoaderConfigPipe } from '../pipes/inject-data-loader-config.pipe'
+
+export const InjectDataLoaderConfig = () => createParamDecorator(() => null)(InjectDataLoaderConfigPipe)

--- a/packages/query-graphql/src/loader/dataloader.factory.ts
+++ b/packages/query-graphql/src/loader/dataloader.factory.ts
@@ -1,6 +1,8 @@
 import { ExecutionContext } from '@nestjs/common'
 import Dataloader from 'dataloader'
 
+import { DataLoaderOptions } from '../pipes/inject-data-loader-config.pipe'
+
 const cacheKeyFn = <K>(key: K): string =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   JSON.stringify(key, (_, v) => (typeof v === 'bigint' ? v.toString() : v))
@@ -15,19 +17,26 @@ export class DataLoaderFactory {
       // eslint-disable-next-line no-param-reassign
       context.nestjsQueryLoaders = {}
     }
+
     return context.nestjsQueryLoaders
   }
 
   static getOrCreateLoader<K, V>(
     context: NestjsQueryExecutionContext,
     name: string,
-    handler: Dataloader.BatchLoadFn<K, V>
+    createHandler: () => Dataloader.BatchLoadFn<K, V>,
+    options?: DataLoaderOptions
   ): Dataloader<K, V> {
     const nestjsQueryLoaders = this.initializeContext(context)
+
     if (!nestjsQueryLoaders[name]) {
+      const handler = createHandler()
+      const dataLoaderOptions = { cacheKeyFn, ...options }
+
       // eslint-disable-next-line no-param-reassign
-      nestjsQueryLoaders[name] = new Dataloader(handler, { cacheKeyFn })
+      nestjsQueryLoaders[name] = new Dataloader<K, V, string>(handler, dataLoaderOptions)
     }
+
     return nestjsQueryLoaders[name] as Dataloader<K, V>
   }
 }

--- a/packages/query-graphql/src/module.ts
+++ b/packages/query-graphql/src/module.ts
@@ -34,7 +34,7 @@ export interface NestjsQueryGraphqlModuleFeatureOpts {
 @Module({})
 export class NestjsQueryGraphQLCoreModule {
   public static forRoot(opts: NestjsQueryGraphqlModuleRootOpts): DynamicModule {
-    const providers = [{ provide: dataLoaderOptionsToken(), useValue: opts.dataLoader ?? {} }]
+    const providers = [{ provide: dataLoaderOptionsToken, useValue: opts.dataLoader ?? {} }]
 
     return {
       module: NestjsQueryGraphQLCoreModule,

--- a/packages/query-graphql/src/module.ts
+++ b/packages/query-graphql/src/module.ts
@@ -1,6 +1,7 @@
-import { DynamicModule, ForwardReference, Provider } from '@nestjs/common'
+import { DynamicModule, ForwardReference, Global, Module, Provider } from '@nestjs/common'
 import { Assembler, Class, NestjsQueryCoreModule } from '@ptc-org/nestjs-query-core'
 
+import { DataLoaderOptions, dataLoaderOptionsToken } from './pipes/inject-data-loader-config.pipe'
 import { AutoResolverOpts, createAuthorizerProviders, createHookProviders, createResolvers } from './providers'
 import { ReadResolverOpts } from './resolvers'
 import { defaultPubSub, GraphQLPubSub, pubSubToken } from './subscription'
@@ -12,7 +13,12 @@ interface DTOModuleOpts<DTO> {
   UpdateDTOClass?: Class<DTO>
 }
 
-export interface NestjsQueryGraphqlModuleOpts {
+export interface NestjsQueryGraphqlModuleRootOpts {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dataLoader?: DataLoaderOptions
+}
+
+export interface NestjsQueryGraphqlModuleFeatureOpts {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   imports?: Array<Class<any> | DynamicModule | Promise<DynamicModule> | ForwardReference>
   services?: Provider[]
@@ -24,8 +30,29 @@ export interface NestjsQueryGraphqlModuleOpts {
   pubSub?: Provider<GraphQLPubSub>
 }
 
+@Global()
+@Module({})
+export class NestjsQueryGraphQLCoreModule {
+  public static forRoot(opts: NestjsQueryGraphqlModuleRootOpts): DynamicModule {
+    const providers = [{ provide: dataLoaderOptionsToken(), useValue: opts.dataLoader ?? {} }]
+
+    return {
+      module: NestjsQueryGraphQLCoreModule,
+      providers,
+      exports: providers
+    }
+  }
+}
+
 export class NestjsQueryGraphQLModule {
-  public static forFeature(opts: NestjsQueryGraphqlModuleOpts): DynamicModule {
+  public static forRoot(opts: NestjsQueryGraphqlModuleRootOpts): DynamicModule {
+    return {
+      module: NestjsQueryGraphQLModule,
+      imports: [NestjsQueryGraphQLCoreModule.forRoot(opts)]
+    }
+  }
+
+  public static forFeature(opts: NestjsQueryGraphqlModuleFeatureOpts): DynamicModule {
     const coreModule = this.getCoreModule(opts)
     const providers = this.getProviders(opts)
     const imports = opts.imports ?? []
@@ -42,14 +69,14 @@ export class NestjsQueryGraphQLModule {
     return { provide: pubSubToken(), useValue: defaultPubSub() }
   }
 
-  private static getCoreModule(opts: NestjsQueryGraphqlModuleOpts): DynamicModule {
+  private static getCoreModule(opts: NestjsQueryGraphqlModuleFeatureOpts): DynamicModule {
     return NestjsQueryCoreModule.forFeature({
       assemblers: opts.assemblers,
       imports: opts.imports ?? []
     })
   }
 
-  private static getProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<unknown>[] {
+  private static getProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<unknown>[] {
     return [
       ...this.getServicesProviders(opts),
       ...this.getPubSubProviders(opts),
@@ -59,25 +86,25 @@ export class NestjsQueryGraphQLModule {
     ]
   }
 
-  private static getPubSubProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<GraphQLPubSub>[] {
+  private static getPubSubProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<GraphQLPubSub>[] {
     return [opts.pubSub ?? this.defaultPubSubProvider()]
   }
 
-  private static getServicesProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<unknown>[] {
+  private static getServicesProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<unknown>[] {
     return opts.services ?? []
   }
 
-  private static getResolverProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<unknown>[] {
+  private static getResolverProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<unknown>[] {
     return createResolvers(opts.resolvers ?? [])
   }
 
-  private static getAuthorizerProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<unknown>[] {
+  private static getAuthorizerProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<unknown>[] {
     const resolverDTOs = opts.resolvers?.map((r) => r.DTOClass) ?? []
     const dtos = opts.dtos?.map((o) => o.DTOClass) ?? []
     return createAuthorizerProviders([...resolverDTOs, ...dtos])
   }
 
-  private static getHookProviders(opts: NestjsQueryGraphqlModuleOpts): Provider<unknown>[] {
+  private static getHookProviders(opts: NestjsQueryGraphqlModuleFeatureOpts): Provider<unknown>[] {
     return createHookProviders([...(opts.resolvers ?? []), ...(opts.dtos ?? [])])
   }
 }

--- a/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
+++ b/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
@@ -1,0 +1,21 @@
+import { Inject, Injectable, PipeTransform } from '@nestjs/common'
+import { Options } from 'dataloader'
+
+export const dataLoaderOptionsToken = () => 'DATALOADER_OPTIONS'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DataLoaderOptions = Options<any, any, any>
+
+@Injectable()
+export class InjectDataLoaderConfigPipe implements PipeTransform {
+  // inject any dependency
+  constructor(
+    @Inject(dataLoaderOptionsToken())
+    private readonly options: DataLoaderOptions
+  ) {
+    //
+  }
+
+  transform() {
+    return this.options
+  }
+}

--- a/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
+++ b/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, PipeTransform } from '@nestjs/common'
+import { ModuleRef } from '@nestjs/core'
 import { Options } from 'dataloader'
 
 export const dataLoaderOptionsToken = () => 'DATALOADER_OPTIONS'
@@ -7,12 +8,17 @@ export type DataLoaderOptions = Options<any, any, any>
 
 @Injectable()
 export class InjectDataLoaderConfigPipe implements PipeTransform {
-  // inject any dependency
+  private readonly options: DataLoaderOptions = {}
+
   constructor(
-    @Inject(dataLoaderOptionsToken())
-    private readonly options: DataLoaderOptions
+    @Inject(ModuleRef)
+    private moduleRef: ModuleRef
   ) {
-    //
+    try {
+      this.options = this.moduleRef.get(dataLoaderOptionsToken(), { strict: false })
+    } catch (error) {
+      //
+    }
   }
 
   transform() {

--- a/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
+++ b/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, PipeTransform } from '@nestjs/common'
 import { ModuleRef } from '@nestjs/core'
 import { Options } from 'dataloader'
 
-export const dataLoaderOptionsToken = () => 'DATALOADER_OPTIONS'
+export const dataLoaderOptionsToken = 'DATALOADER_OPTIONS' as const;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DataLoaderOptions = Options<any, any, any>
 
@@ -15,7 +15,7 @@ export class InjectDataLoaderConfigPipe implements PipeTransform {
     private moduleRef: ModuleRef
   ) {
     try {
-      this.options = this.moduleRef.get(dataLoaderOptionsToken(), { strict: false })
+      this.options = this.moduleRef.get(dataLoaderOptionsToken, { strict: false })
     } catch (error) {
       //
     }

--- a/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
+++ b/packages/query-graphql/src/pipes/inject-data-loader-config.pipe.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, PipeTransform } from '@nestjs/common'
 import { ModuleRef } from '@nestjs/core'
 import { Options } from 'dataloader'
 
-export const dataLoaderOptionsToken = 'DATALOADER_OPTIONS' as const;
+export const dataLoaderOptionsToken = 'DATALOADER_OPTIONS' as const
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DataLoaderOptions = Options<any, any, any>
 

--- a/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
+++ b/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
@@ -79,7 +79,7 @@ type FilterComparisonOptions<T> = {
   FieldType: Class<T>
   fieldName: string
   allowedComparisons?: FilterComparisonOperators<T>[]
-  returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
+  returnTypeFunc?: ReturnTypeFunc
 }
 
 /** @internal */

--- a/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
+++ b/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
@@ -79,7 +79,7 @@ type FilterComparisonOptions<T> = {
   FieldType: Class<T>
   fieldName: string
   allowedComparisons?: FilterComparisonOperators<T>[]
-  returnTypeFunc?: ReturnTypeFunc
+  returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
 }
 
 /** @internal */


### PR DESCRIPTION
We needed the possibility to configure the `batchScheduleFn` of the DataLoader. Because in connection with a `CustomAuthorizer` the default scheduler fails and the n+1 problem occurs again.

Following the NestJS common practice, I implemented the following configuration option in the `AppModule`:

```typescript
NestjsQueryGraphQLModule.forRoot({
  dataLoader: {
    batchScheduleFn(callback) {
      // custom implementation
    },
  },
}),
```
