### PR TITLE
fix(query-typeorm): name collision on deeply nested filters

### DIFF
--- a/examples/filters-deep/e2e/users.resolver.spec.ts
+++ b/examples/filters-deep/e2e/users.resolver.spec.ts
@@ -104,20 +104,20 @@ describe('UsersResolver (filters-deep - e2e)', () => {
               filter: {
                 # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 5 Only", "Post 6 Only"
                 firstName: {
-                  iLike: "%%"
+                  like: "%"
                 }
 
                 # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 5 Only", "Post 6 Only"
                 and: [
                   {
                     lastName: {
-                      iLike: "%%"
+                      like: "%"
                     }
                   },
 
                   {
                     firstName: {
-                      iLike: "%%"
+                      like: "%"
                     }
                   }
                 ]

--- a/examples/filters-deep/e2e/users.resolver.spec.ts
+++ b/examples/filters-deep/e2e/users.resolver.spec.ts
@@ -91,6 +91,145 @@ describe('UsersResolver (filters-deep - e2e)', () => {
           )
         })
     })
+
+    it('should not fail if the same property-name occurs twice', async () => {
+      await request(app.getHttpServer())
+        .post('/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{
+            # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 6 Only"
+            users(
+              filter: {
+                # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 5 Only", "Post 6 Only"
+                firstName: {
+                  iLike: "%%"
+                }
+
+                # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 5 Only", "Post 6 Only"
+                and: [
+                  {
+                    lastName: {
+                      iLike: "%%"
+                    }
+                  },
+
+                  {
+                    firstName: {
+                      iLike: "%%"
+                    }
+                  }
+                ]
+
+                # "John Doe", "Jane Doe", "Post 1 Only", "Post 2 Only", "Post 3 Only", "Post 4 Only", "Post 6 Only"
+                # "Post 1", "Post 2", "Post 3", "Post 4", "Post 6"
+                posts: {
+                  or: [
+                    # "Post 1"
+                    {
+                      title: {
+                        eq: "Post 1"
+                      }
+                    },
+
+                    # "Post 1", "Post 2", "Post 6", "Post 3", "Post 4"
+                    {
+                      # "Sports", "Politics"
+                      categories: {
+                        # "Post 2"
+                        posts: {
+                          and: [
+                            {
+                              title: {
+                                eq: "Post 2"
+                              }
+                            },
+
+                            {
+                              description: {
+                                eq: "Post 2 Description"
+                              }
+                            }
+                          ]
+                        }
+                      }
+
+                      # "John Doe", "Jane Doe", "Post 1 Only"
+                      authors: {
+                        # "Post 1"
+                        posts: {
+                          and: [
+                            {
+                              title: {
+                                eq: "Post 1"
+                              }
+                            },
+
+                            {
+                              description: {
+                                eq: "Post 1 Description"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ) {
+              id
+              firstName
+              lastName
+            }
+          }`
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const users = body.data.users
+
+          expect(users).toHaveLength(7)
+          expect(users).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                firstName: 'John',
+                lastName: 'Doe'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Jane',
+                lastName: 'Doe'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Post 1',
+                lastName: 'Only'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Post 2',
+                lastName: 'Only'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Post 3',
+                lastName: 'Only'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Post 4',
+                lastName: 'Only'
+              }),
+
+              expect.objectContaining({
+                firstName: 'Post 6',
+                lastName: 'Only'
+              })
+            ])
+          )
+        })
+    })
   })
 
   afterAll(async () => {

--- a/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
@@ -24,6 +24,145 @@ describe('FilterQueryBuilder', (): void => {
     expect(formatSql(sql, { params })).toMatchSnapshot()
   }
 
+  describe('#getReferencedRelationsWithAliasRecursive', () => {
+    it('with deeply nested and / or', () => {
+      const complexQuery: Filter<TestEntity> = {
+        and: [
+          {
+            oneTestRelation: {
+              manyTestEntities: {
+                oneTestRelation: {
+                  manyTestEntities: {
+                    stringType: { eq: '123' }
+                  }
+                }
+              }
+            }
+          },
+
+          {
+            or: [
+              { and: [{ stringType: { eq: '123' } }] },
+              {
+                and: [{ stringType: { eq: '123' } }, { testEntityPk: { eq: '123' } }]
+              }
+            ]
+          },
+
+          {
+            stringType: { eq: '345' },
+            or: [
+              { oneTestRelation: { relationName: { eq: '123' } } },
+              { oneTestRelation: { relationOfTestRelation: { testRelationId: { eq: 'e1' } } } }
+            ]
+          }
+        ]
+      }
+
+      const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+      const qb = getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder))
+
+      expect(qb.getReferencedRelationsWithAliasRecursive(qb.repo.metadata, complexQuery)).toEqual({
+        oneTestRelation: {
+          alias: 'oneTestRelation',
+          value: {
+            manyTestEntities: {
+              alias: 'manyTestEntities',
+              value: {
+                oneTestRelation: {
+                  alias: 'oneTestRelation_1',
+                  value: {
+                    manyTestEntities: {
+                      alias: 'manyTestEntities_1',
+                      value: {}
+                    }
+                  }
+                }
+              }
+            },
+
+            relationOfTestRelation: {
+              alias: 'relationOfTestRelation',
+              value: {}
+            }
+          }
+        }
+      })
+    })
+
+    it('with nested and / or', () => {
+      const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+      const qb = getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder))
+
+      const query: Filter<TestEntity> = {
+        stringType: { eq: '123' },
+
+        and: [
+          {
+            boolType: { is: true }
+          },
+          {
+            testRelations: {
+              relationName: { eq: '123' }
+            }
+          }
+        ],
+
+        or: [
+          {
+            boolType: { is: true }
+          },
+          {
+            oneTestRelation: {
+              testRelationPk: { eq: '123' },
+              testEntity: {
+                testRelations: {
+                  relationName: { eq: '123' }
+                }
+              }
+            }
+          },
+          {
+            oneTestRelation: {
+              relationsOfTestRelation: {
+                testRelationId: {
+                  eq: '123'
+                }
+              }
+            }
+          }
+        ]
+      }
+
+      expect(qb.getReferencedRelationsWithAliasRecursive(qb.repo.metadata, query)).toEqual({
+        testRelations: {
+          alias: 'testRelations',
+          value: {}
+        },
+
+        oneTestRelation: {
+          alias: 'oneTestRelation',
+          value: {
+            relationsOfTestRelation: {
+              alias: 'relationsOfTestRelation',
+              value: {}
+            },
+
+            testEntity: {
+              alias: 'testEntity',
+              value: {
+                testRelations: {
+                  alias: 'testRelations_1',
+                  value: {}
+                }
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+
   describe('#getReferencedRelationsRecursive', () => {
     it('with deeply nested and / or', () => {
       const complexQuery: Filter<TestEntity> = {

--- a/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
@@ -65,16 +65,16 @@ describe('FilterQueryBuilder', (): void => {
       expect(qb.getReferencedRelationsWithAliasRecursive(qb.repo.metadata, complexQuery)).toEqual({
         oneTestRelation: {
           alias: 'oneTestRelation',
-          value: {
+          relations: {
             manyTestEntities: {
               alias: 'manyTestEntities',
-              value: {
+              relations: {
                 oneTestRelation: {
                   alias: 'oneTestRelation_1',
-                  value: {
+                  relations: {
                     manyTestEntities: {
                       alias: 'manyTestEntities_1',
-                      value: {}
+                      relations: {}
                     }
                   }
                 }
@@ -83,7 +83,7 @@ describe('FilterQueryBuilder', (): void => {
 
             relationOfTestRelation: {
               alias: 'relationOfTestRelation',
-              value: {}
+              relations: {}
             }
           }
         }
@@ -137,23 +137,23 @@ describe('FilterQueryBuilder', (): void => {
       expect(qb.getReferencedRelationsWithAliasRecursive(qb.repo.metadata, query)).toEqual({
         testRelations: {
           alias: 'testRelations',
-          value: {}
+          relations: {}
         },
 
         oneTestRelation: {
           alias: 'oneTestRelation',
-          value: {
+          relations: {
             relationsOfTestRelation: {
               alias: 'relationsOfTestRelation',
-              value: {}
+              relations: {}
             },
 
             testEntity: {
               alias: 'testEntity',
-              value: {
+              relations: {
                 testRelations: {
                   alias: 'testRelations_1',
-                  value: {}
+                  relations: {}
                 }
               }
             }

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -90,7 +90,7 @@ export class FilterQueryBuilder<Entity> {
    * @param query - the query to apply.
    */
   public select(query: Query<Entity>): SelectQueryBuilder<Entity> {
-    let qb = this.createQueryBuilder()
+    let qb = this.createQueryBuilder().distinct(true)
 
     qb = this.applyRelationJoinsRecursive(
       qb,

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -258,7 +258,7 @@ export class FilterQueryBuilder<Entity> {
     const referencedRelations = Object.keys(relationsMap)
 
     // TODO:: If relation is not nullable use inner join?
-    return referencedRelations.reduce((rqb, relation, i) => {
+    return referencedRelations.reduce((rqb, relation) => {
       // TODO:: Change to find and also apply the query for the relation
       const selectRelation = selectRelations && selectRelations.find(({ name }) => name === relation)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/query-typeorm/src/query/relation-query.builder.ts
+++ b/packages/query-typeorm/src/query/relation-query.builder.ts
@@ -95,7 +95,7 @@ export class RelationQueryBuilder<Entity, Relation> {
     relationBuilder = hasRelations
       ? this.filterQueryBuilder.applyRelationJoinsRecursive(
           relationBuilder,
-          this.filterQueryBuilder.getReferencedRelationsRecursive(this.relationRepo.metadata, query.filter)
+          this.filterQueryBuilder.getReferencedRelationsWithAliasRecursive(this.relationRepo.metadata, query.filter)
         )
       : relationBuilder
 
@@ -111,7 +111,7 @@ export class RelationQueryBuilder<Entity, Relation> {
     qb.withDeleted()
     qb = this.filterQueryBuilder.applyRelationJoinsRecursive(
       qb,
-      this.filterQueryBuilder.getReferencedRelationsRecursive(this.relationRepo.metadata, query.filter, query.relations),
+      this.filterQueryBuilder.getReferencedRelationsWithAliasRecursive(this.relationRepo.metadata, query.filter, query.relations),
       query.relations
     )
     qb = this.filterQueryBuilder.applyFilter(qb, query.filter, qb.alias)


### PR DESCRIPTION
This branch fixes the name collision on the relation-joins. The following query for example would fail, because the generated JOIN-statements were named after the filter-properties.

```graphql
{
  users(
    filter: {
      posts: {
        categories: {
          posts: {
            title: {
              eq: "Post 1"
            }
          }
        }

        authors: {
          posts: {
            title: {
              eq: "Post 1"
            }
          }
        }
      }
    }
  ) {
    id
    firstName
    lastName
  }
}
```

`users -> posts` is a join
`(users -> posts ->) categories -> posts` is another join
`(users -> posts ->) authors -> posts` is another join

For all this joins only the name `posts` was used. `join "post" "posts" on ...` which would lead to the sql error `table name "posts" specified more than once`.
