### PR TITLE
Feat: custom filter decorators and prefix

### DIFF
--- a/packages/query-graphql/__tests__/types/query/__snapshots__/filter.type.spec.ts.snap
+++ b/packages/query-graphql/__tests__/types/query/__snapshots__/filter.type.spec.ts.snap
@@ -708,6 +708,107 @@ input TestBetweenComparisonStringFieldFilterComparison {
 }"
 `;
 
+exports[`filter types FilterType filterDecorators option should apply the decorator to the correct fields 1`] = `
+[
+  {
+    "propertyKey": "eq",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "neq",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "gt",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "gte",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "lt",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "lte",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "like",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notLike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "iLike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notILike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "in",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notIn",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "eq",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "neq",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "gt",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "gte",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "lt",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "lte",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "like",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notLike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "iLike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notILike",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "in",
+    "target": Fc {},
+  },
+  {
+    "propertyKey": "notIn",
+    "target": Fc {},
+  },
+]
+`;
+
 exports[`filter types FilterType filterDepth option different filterDepth options shouldn't affect each other 1`] = `
 "type TestFilterDto {
   id: Float!
@@ -1772,6 +1873,139 @@ input TestFilterDtoFilterTestRelationDtoFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+}"
+`;
+
+exports[`filter types FilterType typeNamePrefix option should apply correct type name prefix 1`] = `
+"type TestFilterDto {
+  id: Float!
+  boolField: Boolean!
+  dateField: DateTime!
+  floatField: Float!
+  intField: Int!
+  numberField: Float!
+  stringField: String!
+  stringEnumField: StringEnum!
+  numberEnumField: NumberEnum!
+  timestampField: Timestamp!
+  nonFilterField: Float!
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+enum StringEnum {
+  ONE_STR
+  TWO_STR
+  THREE_STR
+  FOUR_STR
+}
+
+enum NumberEnum {
+  ONE
+  TWO
+  THREE
+  FOUR
+}
+
+"""
+\`Date\` type as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
+"""
+scalar Timestamp
+
+type TestTypeNamePrefix {
+  id: Float!
+  boolField: Boolean!
+  dateField: DateTime!
+  floatField: Float!
+}
+
+type Query {
+  test(input: TestTypeNamePrefixFilter!): TestTypeNamePrefix!
+}
+
+input TestTypeNamePrefixFilter {
+  and: [TestTypeNamePrefixFilter!]
+  or: [TestTypeNamePrefixFilter!]
+  id: NumberFieldComparison
+  boolField: BooleanFieldComparison
+  dateField: MyDateFilterComparison
+  floatField: MyCustomFloatFilterComparison
+}
+
+input NumberFieldComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: Float
+  neq: Float
+  gt: Float
+  gte: Float
+  lt: Float
+  lte: Float
+  in: [Float!]
+  notIn: [Float!]
+  between: NumberFieldComparisonBetween
+  notBetween: NumberFieldComparisonBetween
+}
+
+input NumberFieldComparisonBetween {
+  lower: Float!
+  upper: Float!
+}
+
+input BooleanFieldComparison {
+  is: Boolean
+  isNot: Boolean
+}
+
+input MyDateFilterComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: DateTime
+  neq: DateTime
+  gt: DateTime
+  gte: DateTime
+  lt: DateTime
+  lte: DateTime
+  like: DateTime
+  notLike: DateTime
+  iLike: DateTime
+  notILike: DateTime
+  in: [DateTime!]
+  notIn: [DateTime!]
+  between: MyDateFilterComparisonBetween
+  notBetween: MyDateFilterComparisonBetween
+}
+
+input MyDateFilterComparisonBetween {
+  lower: DateTime!
+  upper: DateTime!
+}
+
+input MyCustomFloatFilterComparison {
+  is: Boolean
+  isNot: Boolean
+  eq: Float
+  neq: Float
+  gt: Float
+  gte: Float
+  lt: Float
+  lte: Float
+  like: Float
+  notLike: Float
+  iLike: Float
+  notILike: Float
+  in: [Float!]
+  notIn: [Float!]
+  between: MyCustomFloatFilterComparisonBetween
+  notBetween: MyCustomFloatFilterComparisonBetween
+}
+
+input MyCustomFloatFilterComparisonBetween {
+  lower: Float!
+  upper: Float!
 }"
 `;
 

--- a/packages/query-graphql/__tests__/types/query/filter.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/query/filter.type.spec.ts
@@ -307,10 +307,10 @@ describe('filter types', (): void => {
         @FilterableField()
         boolField!: boolean
 
-        @FilterableField({ filterTypeNamePrefix: `MyDate` })
+        @FilterableField({ overrideFilterTypeNamePrefix: `MyDate` })
         dateField!: Date
 
-        @FilterableField({ filterTypeNamePrefix: `MyCustomFloat` })
+        @FilterableField({ overrideFilterTypeNamePrefix: `MyCustomFloat` })
         floatField!: number
       }
 

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -9,7 +9,7 @@ export type FilterableFieldOptions = {
   filterRequired?: boolean
   filterOnly?: boolean
   filterDecorators?: PropertyDecorator[]
-  filterTypeNamePrefix?: string
+  overrideFilterTypeNamePrefix?: string
 } & FieldOptions
 
 export interface FilterableFieldDescriptor {

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -8,6 +8,7 @@ export type FilterableFieldOptions = {
   allowedComparisons?: FilterComparisonOperators<unknown>[]
   filterRequired?: boolean
   filterOnly?: boolean
+  filterDecorators?: PropertyDecorator[]
 } & FieldOptions
 
 export interface FilterableFieldDescriptor {

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -9,6 +9,7 @@ export type FilterableFieldOptions = {
   filterRequired?: boolean
   filterOnly?: boolean
   filterDecorators?: PropertyDecorator[]
+  filterTypeNamePrefix?: string
 } & FieldOptions
 
 export interface FilterableFieldDescriptor {

--- a/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
+++ b/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
@@ -70,8 +70,8 @@ const isCustomFieldComparison = <T>(options: FilterComparisonOptions<T>): boolea
   !!options.allowedComparisons || !!options.decorators
 
 const getComparisonTypeName = <T>(fieldType: ReturnTypeFuncValue, options: FilterComparisonOptions<T>): string => {
-  if (options.typeNamePrefix) {
-    return `${options.typeNamePrefix}FilterComparison`
+  if (options.overrideTypeNamePrefix) {
+    return `${options.overrideTypeNamePrefix}FilterComparison`
   }
   if (isCustomFieldComparison(options)) {
     return `${upperCaseFirst(options.fieldName)}FilterComparison`
@@ -85,7 +85,7 @@ type FilterComparisonOptions<T> = {
   allowedComparisons?: FilterComparisonOperators<T>[]
   returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
   decorators?: PropertyDecorator[]
-  typeNamePrefix?: string
+  overrideTypeNamePrefix?: string
 }
 
 /** @internal */

--- a/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
+++ b/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
@@ -15,7 +15,7 @@ import { IsBoolean, IsDate, IsOptional, ValidateNested } from 'class-validator'
 import { upperCaseFirst } from 'upper-case-first'
 
 import { getGraphqlEnumMetadata } from '../../../common'
-import { SkipIf, composeDecorators } from '../../../decorators'
+import { composeDecorators, SkipIf } from '../../../decorators'
 import { IsUndefined } from '../../validators'
 import { isInAllowedList } from '../helpers'
 import { getOrCreateBooleanFieldComparison } from './boolean-field-comparison.type'
@@ -70,8 +70,8 @@ const isCustomFieldComparison = <T>(options: FilterComparisonOptions<T>): boolea
   !!options.allowedComparisons || !!options.decorators
 
 const getComparisonTypeName = <T>(fieldType: ReturnTypeFuncValue, options: FilterComparisonOptions<T>): string => {
-  if (options.filterTypeNamePrefix) {
-    return `${options.filterTypeNamePrefix}FilterComparison`
+  if (options.typeNamePrefix) {
+    return `${options.typeNamePrefix}FilterComparison`
   }
   if (isCustomFieldComparison(options)) {
     return `${upperCaseFirst(options.fieldName)}FilterComparison`
@@ -85,7 +85,7 @@ type FilterComparisonOptions<T> = {
   allowedComparisons?: FilterComparisonOperators<T>[]
   returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
   decorators?: PropertyDecorator[]
-  filterTypeNamePrefix?: string
+  typeNamePrefix?: string
 }
 
 /** @internal */

--- a/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
+++ b/packages/query-graphql/src/types/query/field-comparison/field-comparison.factory.ts
@@ -15,7 +15,7 @@ import { IsBoolean, IsDate, IsOptional, ValidateNested } from 'class-validator'
 import { upperCaseFirst } from 'upper-case-first'
 
 import { getGraphqlEnumMetadata } from '../../../common'
-import { SkipIf } from '../../../decorators'
+import { SkipIf, composeDecorators } from '../../../decorators'
 import { IsUndefined } from '../../validators'
 import { isInAllowedList } from '../helpers'
 import { getOrCreateBooleanFieldComparison } from './boolean-field-comparison.type'
@@ -66,9 +66,13 @@ const getTypeName = (SomeType: ReturnTypeFuncValue): string => {
   throw new Error(`Unable to create filter comparison for ${JSON.stringify(SomeType)}.`)
 }
 
-const isCustomFieldComparison = <T>(options: FilterComparisonOptions<T>): boolean => !!options.allowedComparisons
+const isCustomFieldComparison = <T>(options: FilterComparisonOptions<T>): boolean =>
+  !!options.allowedComparisons || !!options.decorators
 
 const getComparisonTypeName = <T>(fieldType: ReturnTypeFuncValue, options: FilterComparisonOptions<T>): string => {
+  if (options.filterTypeNamePrefix) {
+    return `${options.filterTypeNamePrefix}FilterComparison`
+  }
   if (isCustomFieldComparison(options)) {
     return `${upperCaseFirst(options.fieldName)}FilterComparison`
   }
@@ -80,14 +84,17 @@ type FilterComparisonOptions<T> = {
   fieldName: string
   allowedComparisons?: FilterComparisonOperators<T>[]
   returnTypeFunc?: ReturnTypeFunc<ReturnTypeFuncValue>
+  decorators?: PropertyDecorator[]
+  filterTypeNamePrefix?: string
 }
 
 /** @internal */
 export function createFilterComparisonType<T>(options: FilterComparisonOptions<T>): Class<FilterFieldComparison<T>> {
-  const { FieldType, returnTypeFunc } = options
+  const { FieldType, returnTypeFunc, decorators = [] } = options
   const fieldType = returnTypeFunc ? returnTypeFunc() : FieldType
   const inputName = getComparisonTypeName(fieldType, options)
   const generator = filterComparisonMap.get(inputName)
+  const CustomDecorator = () => composeDecorators(...decorators)
 
   if (generator) {
     return generator() as Class<FilterFieldComparison<T>>
@@ -129,61 +136,73 @@ export function createFilterComparisonType<T>(options: FilterComparisonOptions<T
     @SkipIf(isNotAllowed('eq'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     eq?: T
 
     @SkipIf(isNotAllowed('neq'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     neq?: T
 
     @SkipIf(isNotAllowed('gt'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     gt?: T
 
     @SkipIf(isNotAllowed('gte'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     gte?: T
 
     @SkipIf(isNotAllowed('lt'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     lt?: T
 
     @SkipIf(isNotAllowed('lte'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     lte?: T
 
     @SkipIf(isNotAllowed('like'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     like?: T
 
     @SkipIf(isNotAllowed('notLike'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     notLike?: T
 
     @SkipIf(isNotAllowed('iLike'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     iLike?: T
 
     @SkipIf(isNotAllowed('notILike'), Field(() => fieldType, { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     notILike?: T;
 
     @SkipIf(isNotAllowed('in'), Field(() => [fieldType], { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     in?: T[]
 
     @SkipIf(isNotAllowed('notIn'), Field(() => [fieldType], { nullable: true }))
     @IsUndefined()
     @Type(() => FieldType)
+    @CustomDecorator()
     notIn?: T[]
 
     @SkipIf(isNotAllowed('between', allowedBetweenTypes), Field(() => FcBetween, { nullable: true }))

--- a/packages/query-graphql/src/types/query/filter.type.ts
+++ b/packages/query-graphql/src/types/query/filter.type.ts
@@ -111,7 +111,8 @@ function getOrCreateFilterType<T>(
             fieldName: `${baseName}${upperCaseFirst(propertyName)}`,
             allowedComparisons: advancedOptions?.allowedComparisons,
             returnTypeFunc,
-            decorators: advancedOptions?.filterDecorators
+            decorators: advancedOptions?.filterDecorators,
+            typeNamePrefix: advancedOptions?.filterTypeNamePrefix
           })
       const nullable = advancedOptions?.filterRequired !== true
       ValidateNested()(GraphQLFilter.prototype, propertyName)

--- a/packages/query-graphql/src/types/query/filter.type.ts
+++ b/packages/query-graphql/src/types/query/filter.type.ts
@@ -110,7 +110,8 @@ function getOrCreateFilterType<T>(
             FieldType: target,
             fieldName: `${baseName}${upperCaseFirst(propertyName)}`,
             allowedComparisons: advancedOptions?.allowedComparisons,
-            returnTypeFunc
+            returnTypeFunc,
+            decorators: advancedOptions?.filterDecorators
           })
       const nullable = advancedOptions?.filterRequired !== true
       ValidateNested()(GraphQLFilter.prototype, propertyName)

--- a/packages/query-graphql/src/types/query/filter.type.ts
+++ b/packages/query-graphql/src/types/query/filter.type.ts
@@ -112,7 +112,7 @@ function getOrCreateFilterType<T>(
             allowedComparisons: advancedOptions?.allowedComparisons,
             returnTypeFunc,
             decorators: advancedOptions?.filterDecorators,
-            typeNamePrefix: advancedOptions?.filterTypeNamePrefix
+            overrideTypeNamePrefix: advancedOptions?.overrideFilterTypeNamePrefix
           })
       const nullable = advancedOptions?.filterRequired !== true
       ValidateNested()(GraphQLFilter.prototype, propertyName)


### PR DESCRIPTION
Now we can add custom filter decorators and name prefixes to DTO properties

This can be used for, eg,

![image](https://github.com/TriPSs/nestjs-query/assets/27646811/e6689c9e-8c7c-41cd-9292-87d3af92f5ce)

Note: This was required for raw mongoose ObjectId filter query search, as applying Transform is required for correct value to be deserialized