### PR TITLE
fix(query-graphql): Fixed relations not respecting the given name

### DIFF
--- a/examples/dataloader-configuration/schema.gql
+++ b/examples/dataloader-configuration/schema.gql
@@ -197,7 +197,7 @@ type SubTask {
   created: DateTime!
   updated: DateTime!
   todoItemId: String!
-  todoItems(
+  todoItem(
     """Specify to filter the records returned."""
     filter: TodoItemFilter! = {}
 

--- a/packages/query-graphql/__tests__/resolvers/federation/__snapshots__/federation.resolver.spec.ts.snap
+++ b/packages/query-graphql/__tests__/resolvers/federation/__snapshots__/federation.resolver.spec.ts.snap
@@ -67,7 +67,7 @@ type TestFederated {
     """Specify to sort results."""
     sorting: [TestRelationDTOSort!]! = []
   ): [TestRelationDTO!]!
-  relationOffsetConnections(
+  relationOffset(
     """Limit or page results."""
     paging: OffsetPaging! = {limit: 10}
 
@@ -76,7 +76,7 @@ type TestFederated {
 
     """Specify to sort results."""
     sorting: [TestRelationDTOSort!]! = []
-  ): TestFederatedRelationOffsetConnectionsConnection!
+  ): TestFederatedRelationOffsetConnection!
   relationCursorConnections(
     """Limit or page results."""
     paging: CursorPaging! = {first: 10}
@@ -216,7 +216,7 @@ type OffsetPageInfo {
   hasPreviousPage: Boolean
 }
 
-type TestFederatedRelationOffsetConnectionsConnection {
+type TestFederatedRelationOffsetConnection {
   """Paging information"""
   pageInfo: OffsetPageInfo!
 

--- a/packages/query-graphql/__tests__/resolvers/federation/federation.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/federation/federation.resolver.spec.ts
@@ -31,8 +31,12 @@ describe('FederationResolver', () => {
   @Relation('relation', () => TestRelationDTO)
   @Relation('custom', () => TestRelationDTO, { relationName: 'other' })
   @UnPagedRelation('unPagedRelations', () => TestRelationDTO)
-  @OffsetConnection('relationOffsetConnection', () => TestRelationDTO)
-  @CursorConnection('relationCursorConnection', () => TestRelationDTO)
+  @OffsetConnection('relationOffset', () => TestRelationDTO, {
+    relationName: 'relationOffsetConnection'
+  })
+  @CursorConnection('relationCursorConnections', () => TestRelationDTO, {
+    relationName: 'relationCursorConnection'
+  })
   class TestFederatedDTO extends TestResolverDTO {
     @FilterableField(() => ID)
     id!: string
@@ -131,7 +135,7 @@ describe('FederationResolver', () => {
         when(
           mockService.queryRelations(
             TestRelationDTO,
-            'relationCursorConnections',
+            'relationCursorConnection',
             deepEqual([dto]),
             objectContaining({ ...query, paging: { limit: 2, offset: 0 } })
           )
@@ -181,14 +185,14 @@ describe('FederationResolver', () => {
       when(
         mockService.queryRelations(
           TestRelationDTO,
-          'relationOffsetConnections',
+          'relationOffsetConnection',
           deepEqual([dto]),
           objectContaining({ ...query, paging: { limit: 2 } })
         )
       ).thenResolve(new Map([[dto, output]]))
       // @ts-ignore
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      const result = await resolver.queryRelationOffsetConnections(dto, query, {})
+      const result = await resolver.queryRelationOffset(dto, query, {})
       return expect(result).toEqual({
         nodes: output,
         pageInfo: { hasNextPage: false, hasPreviousPage: false },

--- a/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/1.spec.ts.snap
+++ b/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/1.spec.ts.snap
@@ -4,13 +4,13 @@ exports[`ReadRelationsResolver - many - 1 should not add filter argument if disa
 "type TestResolverDTO {
   id: ID!
   stringField: String!
-  relations(
+  relation(
     """Limit or page results."""
     paging: CursorPaging! = {first: 10}
 
     """Specify to sort results."""
     sorting: [TestRelationDTOSort!]! = []
-  ): TestResolverDTORelationsConnection!
+  ): TestResolverDTORelationConnection!
 }
 
 input CursorPaging {
@@ -80,7 +80,7 @@ type PageInfo {
   endCursor: ConnectionCursor
 }
 
-type TestResolverDTORelationsConnection {
+type TestResolverDTORelationConnection {
   """Paging information"""
   pageInfo: PageInfo!
 

--- a/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/2.spec.ts.snap
+++ b/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/2.spec.ts.snap
@@ -4,13 +4,13 @@ exports[`ReadRelationsResolver - many - 2 should not add sorting argument if dis
 "type TestResolverDTO {
   id: ID!
   stringField: String!
-  relations(
+  relation(
     """Limit or page results."""
     paging: CursorPaging! = {first: 10}
 
     """Specify to filter the records returned."""
     filter: TestRelationDTOFilter! = {}
-  ): TestResolverDTORelationsConnection!
+  ): TestResolverDTORelationConnection!
 }
 
 input CursorPaging {
@@ -98,7 +98,7 @@ type PageInfo {
   endCursor: ConnectionCursor
 }
 
-type TestResolverDTORelationsConnection {
+type TestResolverDTORelationConnection {
   """Paging information"""
   pageInfo: PageInfo!
 

--- a/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/4.spec.ts.snap
+++ b/packages/query-graphql/__tests__/resolvers/relations/read-relation/many/__snapshots__/4.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`ReadRelationsResolver - many - 4 should use the dtoName if provided 1`]
 "type TestResolverDTO {
   id: ID!
   stringField: String!
-  tests(
+  test(
     """Limit or page results."""
     paging: CursorPaging! = {first: 10}
 
@@ -13,7 +13,7 @@ exports[`ReadRelationsResolver - many - 4 should use the dtoName if provided 1`]
 
     """Specify to sort results."""
     sorting: [TestRelationDTOSort!]! = []
-  ): TestResolverDTOTestsConnection!
+  ): TestResolverDTOTestConnection!
 }
 
 input CursorPaging {
@@ -124,7 +124,7 @@ type PageInfo {
   endCursor: ConnectionCursor
 }
 
-type TestResolverDTOTestsConnection {
+type TestResolverDTOTestConnection {
   """Paging information"""
   pageInfo: PageInfo!
 

--- a/packages/query-graphql/src/resolvers/relations/read-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/read-relations.resolver.ts
@@ -84,13 +84,13 @@ const ReadManyRelationMixin =
     const commonResolverOpts = removeRelationOpts(relation)
     const relationDTO = relation.DTO
     const dtoName = getDTONames(DTOClass).baseName
-    const { pluralBaseNameLower, pluralBaseName } = getDTONames(relationDTO, { dtoName: relation.dtoName })
-    const relationName = relation.relationName ?? pluralBaseNameLower
-    const relationLoaderName = `load${pluralBaseName}For${DTOClass.name}`
-    const countRelationLoaderName = `count${pluralBaseName}For${DTOClass.name}`
+    const { baseNameLower, baseName } = getDTONames(relationDTO, { dtoName: relation.dtoName })
+    const relationName = relation.relationName ?? baseNameLower
+    const relationLoaderName = `load${baseName}For${DTOClass.name}`
+    const countRelationLoaderName = `count${baseName}For${DTOClass.name}`
     const queryLoader = new QueryRelationsLoader<DTO, Relation>(relationDTO, relationName)
     const countLoader = new CountRelationsLoader<DTO, Relation>(relationDTO, relationName)
-    const connectionName = `${dtoName}${pluralBaseName}Connection`
+    const connectionName = `${dtoName}${baseName}Connection`
 
     @ArgsType()
     class RelationQA extends QueryArgsType(relationDTO, {
@@ -105,17 +105,17 @@ const ReadManyRelationMixin =
     @Resolver(() => DTOClass, { isAbstract: true })
     class ReadManyMixin extends Base {
       @ResolverField(
-        pluralBaseNameLower,
+        baseNameLower,
         () => CT.resolveType,
         { nullable: relation.nullable, complexity: relation.complexity, description: relation?.description },
         commonResolverOpts,
         { interceptors: [AuthorizerInterceptor(DTOClass)] }
       )
-      async [`query${pluralBaseName}`](
+      async [`query${baseName}`](
         @Parent() dto: DTO,
         @Args() q: RelationQA,
         @Context() context: ExecutionContext,
-        @RelationAuthorizerFilter(pluralBaseNameLower, {
+        @RelationAuthorizerFilter(baseNameLower, {
           operationGroup: OperationGroup.READ,
           many: true
         })


### PR DESCRIPTION
BREAKING CHANGE: Relation names are no longer automatically pluralized and respect the given name

Fixes #217