### PR TITLE
chore(deps):update mongoose peerDependencies

### DIFF
--- a/packages/query-mongoose/package.json
+++ b/packages/query-mongoose/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0",
     "@nestjs/mongoose": "^9.0.0 || ^10.0.0",
-    "mongoose": "^6.5.0"
+    "mongoose": "^6.5.0 || ^7.0.0 || ^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/query-typegoose/package.json
+++ b/packages/query-typegoose/package.json
@@ -28,7 +28,7 @@
     "@m8a/nestjs-typegoose": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs/common": "^9.0.0 || ^10.0.0",
     "@typegoose/typegoose": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "mongoose": "^6.5.0 || ^7.0.3"
+    "mongoose": "^6.5.0 || ^7.0.3 || ^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,7 +5530,7 @@ __metadata:
   peerDependencies:
     "@nestjs/common": ^9.0.0 || ^10.0.0
     "@nestjs/mongoose": ^9.0.0 || ^10.0.0
-    mongoose: ^6.5.0
+    mongoose: ^6.5.0 || ^7.0.0 || ^8.0.0
   languageName: unknown
   linkType: soft
 
@@ -5562,7 +5562,7 @@ __metadata:
     "@m8a/nestjs-typegoose": ^9.0.0 || ^10.0.0 || ^11.0.0
     "@nestjs/common": ^9.0.0 || ^10.0.0
     "@typegoose/typegoose": ^9.0.0 || ^10.0.0 || ^11.0.0
-    mongoose: ^6.5.0 || ^7.0.3
+    mongoose: ^6.5.0 || ^7.0.3 || ^8.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Updates the peer dependencies of `query-mongoose` and `query-typegoose` so that they can be installed with latest mongoose version.