### PR TITLE
fix: Corrected missing promises in functions that should have been present

### DIFF
--- a/examples/auth/src/todo-item/todo-item.assembler.ts
+++ b/examples/auth/src/todo-item/todo-item.assembler.ts
@@ -6,7 +6,7 @@ import { TodoItemEntity } from './todo-item.entity'
 @Assembler(TodoItemDTO, TodoItemEntity)
 export class TodoItemAssembler extends ClassTransformerAssembler<TodoItemDTO, TodoItemEntity> {
   convertToDTO(entity: TodoItemEntity): TodoItemDTO {
-    const dto = super.convertToDTO(entity)
+    const dto = super.convertToDTO(entity) as TodoItemDTO
     dto.age = Date.now() - entity.created.getMilliseconds()
     return dto
   }

--- a/examples/mongoose/src/todo-item/todo-item.assembler.ts
+++ b/examples/mongoose/src/todo-item/todo-item.assembler.ts
@@ -6,7 +6,7 @@ import { TodoItemEntity } from './todo-item.entity'
 @Assembler(TodoItemDTO, TodoItemEntity)
 export class TodoItemAssembler extends ClassTransformerAssembler<TodoItemDTO, TodoItemEntity> {
   convertToDTO(entity: TodoItemEntity): TodoItemDTO {
-    const dto = super.convertToDTO(entity)
+    const dto = super.convertToDTO(entity) as TodoItemDTO
     dto.age = Date.now() - entity.createdAt.getMilliseconds()
     return dto
   }

--- a/examples/sequelize/src/todo-item/todo-item.assembler.ts
+++ b/examples/sequelize/src/todo-item/todo-item.assembler.ts
@@ -6,7 +6,7 @@ import { TodoItemEntity } from './entity/todo-item.entity'
 @Assembler(TodoItemDTO, TodoItemEntity)
 export class TodoItemAssembler extends ClassTransformerAssembler<TodoItemDTO, TodoItemEntity> {
   convertToDTO(entity: TodoItemEntity): TodoItemDTO {
-    const dto = super.convertToDTO(entity)
+    const dto = super.convertToDTO(entity) as TodoItemDTO
     dto.age = Date.now() - entity.created.getMilliseconds()
     return dto
   }

--- a/examples/typegoose/src/todo-item/todo-item.assembler.ts
+++ b/examples/typegoose/src/todo-item/todo-item.assembler.ts
@@ -6,7 +6,7 @@ import { TodoItemEntity } from './todo-item.entity'
 @Assembler(TodoItemDTO, TodoItemEntity)
 export class TodoItemAssembler extends ClassTransformerAssembler<TodoItemDTO, TodoItemEntity> {
   convertToDTO(entity: TodoItemEntity): TodoItemDTO {
-    const dto = super.convertToDTO(entity)
+    const dto = super.convertToDTO(entity) as TodoItemDTO
     dto.age = Date.now() - entity.createdAt.getMilliseconds()
     return dto
   }

--- a/examples/typeorm/src/todo-item/todo-item.assembler.ts
+++ b/examples/typeorm/src/todo-item/todo-item.assembler.ts
@@ -6,7 +6,7 @@ import { TodoItemEntity } from './todo-item.entity'
 @Assembler(TodoItemDTO, TodoItemEntity)
 export class TodoItemAssembler extends ClassTransformerAssembler<TodoItemDTO, TodoItemEntity> {
   convertToDTO(entity: TodoItemEntity): TodoItemDTO {
-    const dto = super.convertToDTO(entity)
+    const dto = super.convertToDTO(entity) as TodoItemDTO
     dto.age = Date.now() - entity.created.getMilliseconds()
     return dto
   }

--- a/packages/core/src/assemblers/class-transformer.assembler.ts
+++ b/packages/core/src/assemblers/class-transformer.assembler.ts
@@ -17,11 +17,11 @@ export abstract class ClassTransformerAssembler<DTO, Entity extends DeepPartial<
   DeepPartial<DTO>,
   DeepPartial<Entity>
 > {
-  public convertToDTO(entity: Entity): DTO {
+  public convertToDTO(entity: Entity): DTO | Promise<DTO> {
     return this.convert(this.DTOClass, this.toPlain(entity))
   }
 
-  public convertToEntity(dto: DTO): Entity {
+  public convertToEntity(dto: DTO): Entity | Promise<Entity> {
     return this.convert(this.EntityClass, this.toPlain(dto))
   }
 
@@ -37,11 +37,11 @@ export abstract class ClassTransformerAssembler<DTO, Entity extends DeepPartial<
     return aggregate as unknown as AggregateResponse<DTO>
   }
 
-  public convertToCreateEntity(create: DeepPartial<DTO>): DeepPartial<Entity> {
+  public convertToCreateEntity(create: DeepPartial<DTO>): DeepPartial<Entity> | Promise<DeepPartial<Entity>> {
     return this.convert(this.EntityClass, create)
   }
 
-  public convertToUpdateEntity(create: DeepPartial<DTO>): DeepPartial<Entity> {
+  public convertToUpdateEntity(create: DeepPartial<DTO>): DeepPartial<Entity> | Promise<DeepPartial<Entity>> {
     return this.convert(this.EntityClass, create)
   }
 


### PR DESCRIPTION
In the AbstractAssembler, there are several methods that provide the option to be async.

https://github.com/TriPSs/nestjs-query/blob/b5c761bd42ceccfd8d68e34722706b463b31d73c/packages/core/src/assemblers/abstract.assembler.ts#L37-L39

https://github.com/TriPSs/nestjs-query/blob/b5c761bd42ceccfd8d68e34722706b463b31d73c/packages/core/src/assemblers/abstract.assembler.ts#L47-L49

However, in the ClassTransformerAssembler class, when extending these abstract methods, we explicitly set return types to one of the two return type options:

https://github.com/TriPSs/nestjs-query/blob/b5c761bd42ceccfd8d68e34722706b463b31d73c/packages/core/src/assemblers/class-transformer.assembler.ts#L20-L26

https://github.com/TriPSs/nestjs-query/blob/b5c761bd42ceccfd8d68e34722706b463b31d73c/packages/core/src/assemblers/class-transformer.assembler.ts#L40-L46

Which cause this in my project:

![image](https://github.com/TriPSs/nestjs-query/assets/26123873/578634ae-2704-4ffe-bc55-bb509754bd00)

Which prohibited the use of the async option.

When I change the types: 

![image](https://github.com/TriPSs/nestjs-query/assets/26123873/44d930ff-8a69-4deb-8ef1-043f483c3bcf)

Everything works as expected:

![image](https://github.com/TriPSs/nestjs-query/assets/26123873/05c45bed-b691-4fad-b528-96db6b49badf)

Which is what I hope this PR achieved!