### PR TITLE
Change the `peerDependencies` version of `query-graphql`

### DIFF
--- a/packages/query-graphql/package.json
+++ b/packages/query-graphql/package.json
@@ -43,7 +43,7 @@
     "class-transformer": "^0.5",
     "class-validator": "^0.14.0",
     "graphql": "^16.0.0",
-    "graphql-subscriptions": "^2.0.0",
+    "graphql-subscriptions": "^3.0.0",
     "ts-morph": "^19.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4558,7 +4558,7 @@ __metadata:
     class-transformer: ^0.5
     class-validator: ^0.14.0
     graphql: ^16.0.0
-    graphql-subscriptions: ^2.0.0
+    graphql-subscriptions: ^3.0.0
     ts-morph: ^19.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Sorry for doing it haphazardly :bow:.

So here I increased the missing peerDep version.

Related to: https://github.com/TriPSs/nestjs-query/pull/330