### PR TITLE
chore: typed jest conf + remove `version` from compose file + fix typo

### DIFF
--- a/documentation/docs/introduction/example.mdx
+++ b/documentation/docs/introduction/example.mdx
@@ -270,6 +270,7 @@ npx nest g cl todo-item.create.dto todo-item --flat
 
 
 ```ts title="todo-item/todo-item.create.dto.ts"
+import { Field, InputType } from '@nestjs/graphql';
 import { IsBoolean, IsString } from 'class-validator';
 
 @InputType('CreateTodoItem')
@@ -453,6 +454,7 @@ import { TodoItemModule } from './todo-item/todo-item.module';
       type: 'postgres',
       database: 'gettingstarted',
       username: 'gettingstarted',
+      password: 'gettingstarted',
       autoLoadEntities: true,
       synchronize: true,
       logging: true,
@@ -567,17 +569,16 @@ export class AppModule {}
 </TabItem>
 </Tabs>
 
-Create a `docker-compose.yml` file in the root of the project
+Create a `compose.yml` file in the root of the project
 
 ```dockerfile
-version: "3"
-
 services:
   postgres:
-    image: "postgres:11.5"
+    image: "postgres:17.0-alpine3.20"
     environment:
       - "POSTGRES_USER=gettingstarted"
       - "POSTGRES_DB=gettingstarted"
+      - "POSTGRES_PASSWORD=gettingstarted"
     expose:
       - "5432"
     ports:

--- a/documentation/docs/introduction/example.mdx
+++ b/documentation/docs/introduction/example.mdx
@@ -574,7 +574,7 @@ Create a `compose.yml` file in the root of the project
 ```dockerfile
 services:
   postgres:
-    image: "postgres:17.0-alpine3.20"
+    image: "postgres:17"
     environment:
       - "POSTGRES_USER=gettingstarted"
       - "POSTGRES_DB=gettingstarted"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   postgres:
     image: "postgres:14"

--- a/jest.e2e.ts
+++ b/jest.e2e.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+import type { Config } from 'jest'
+
 export default {
   displayName: 'examples',
   preset: './jest.preset.js',
@@ -16,4 +17,4 @@ export default {
   testMatch: ['**/examples/**/e2e/**/*.spec.ts'],
   setupFilesAfterEnv: ['jest-extended'],
   coverageDirectory: './coverage/examples'
-}
+} satisfies Config

--- a/packages/query-graphql/__tests__/resolvers/crud.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/crud.resolver.spec.ts
@@ -9,7 +9,7 @@ import * as updateResolver from '../../src/resolvers/update.resolver'
 describe('CrudResolver', () => {
   const creatableSpy = jest.spyOn(createResolver, 'Creatable')
   const readableSpy = jest.spyOn(readResolver, 'Readable')
-  const updateableSpy = jest.spyOn(updateResolver, 'Updateable')
+  const updatableSpy = jest.spyOn(updateResolver, 'Updatable')
   const deleteResolverSpy = jest.spyOn(deleteResolver, 'DeleteResolver')
 
   beforeEach(() => jest.clearAllMocks())
@@ -49,8 +49,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)
@@ -65,8 +65,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)
@@ -81,8 +81,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)
@@ -96,8 +96,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, { UpdateDTOClass: UpdateTestResolverDTO })
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, { UpdateDTOClass: UpdateTestResolverDTO })
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)
@@ -111,8 +111,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, { UpdateDTOClass: UpdateTestResolverDTO, guards: [] })
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, { UpdateDTOClass: UpdateTestResolverDTO, guards: [] })
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)
@@ -127,8 +127,8 @@ describe('CrudResolver', () => {
     expect(readableSpy).toHaveBeenCalledWith(TestResolverDTO, { pagingStrategy: PagingStrategies.OFFSET })
     expect(readableSpy).toHaveBeenCalledTimes(1)
 
-    expect(updateableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
-    expect(updateableSpy).toHaveBeenCalledTimes(1)
+    expect(updatableSpy).toHaveBeenCalledWith(TestResolverDTO, {})
+    expect(updatableSpy).toHaveBeenCalledTimes(1)
 
     expect(deleteResolverSpy).toHaveBeenCalledWith(TestResolverDTO, {})
     expect(deleteResolverSpy).toHaveBeenCalledTimes(1)

--- a/packages/query-graphql/src/resolvers/crud.resolver.ts
+++ b/packages/query-graphql/src/resolvers/crud.resolver.ts
@@ -11,7 +11,7 @@ import { Referenceable, ReferenceResolverOpts } from './reference.resolver'
 import { Relatable } from './relations'
 import { RelatableOpts } from './relations/relations.resolver'
 import { MergePagingStrategyOpts, ResolverClass } from './resolver.interface'
-import { Updateable, UpdateResolver, UpdateResolverOpts } from './update.resolver'
+import { Updatable, UpdateResolver, UpdateResolverOpts } from './update.resolver'
 
 export interface CRUDResolverOpts<
   DTO,
@@ -129,13 +129,13 @@ export const CRUDResolver = <
   DTOClass: Class<DTO>,
   opts: CRUDResolverOpts<DTO, C, U, R, PS> = {}
 ): ResolverClass<DTO, QueryService<DTO, C, U>, CRUDResolver<DTO, C, U, MergePagingStrategyOpts<DTO, R, PS>>> => {
-  const referencable = Referenceable(DTOClass, opts.referenceBy ?? {})
+  const referenceable = Referenceable(DTOClass, opts.referenceBy ?? {})
   const relatable = Relatable(DTOClass, extractRelatableOpts(opts))
   const aggregateable = Aggregateable(DTOClass, extractAggregateResolverOpts(opts))
   const creatable = Creatable(DTOClass, extractCreateResolverOpts(opts))
   const readable = Readable(DTOClass, extractReadResolverOpts(opts))
-  const updatable = Updateable(DTOClass, extractUpdateResolverOpts(opts))
+  const updatable = Updatable(DTOClass, extractUpdateResolverOpts(opts))
   const deleteResolver = DeleteResolver(DTOClass, extractDeleteResolverOpts(opts))
 
-  return referencable(relatable(aggregateable(creatable(readable(updatable(deleteResolver))))))
+  return referenceable(relatable(aggregateable(creatable(readable(updatable(deleteResolver))))))
 }

--- a/packages/query-graphql/src/resolvers/update.resolver.ts
+++ b/packages/query-graphql/src/resolvers/update.resolver.ts
@@ -88,7 +88,7 @@ const defaultUpdateManyInput = <DTO, U>(
  * @internal
  * Mixin to add `update` graphql endpoints.
  */
-export const Updateable =
+export const Updatable =
   <DTO, U, QS extends QueryService<DTO, unknown, U>>(DTOClass: Class<DTO>, opts: UpdateResolverOpts<DTO, U>) =>
   <B extends Class<ServiceResolver<DTO, QS>>>(BaseClass: B): Class<UpdateResolver<DTO, U, QS>> & B => {
     const dtoNames = getDTONames(DTOClass, opts)
@@ -233,4 +233,4 @@ export const UpdateResolver = <
 >(
   DTOClass: Class<DTO>,
   opts: UpdateResolverOpts<DTO, U> = {}
-): ResolverClass<DTO, QS, UpdateResolver<DTO, U, QS>> => Updateable(DTOClass, opts)(BaseServiceResolver)
+): ResolverClass<DTO, QS, UpdateResolver<DTO, U, QS>> => Updatable(DTOClass, opts)(BaseServiceResolver)


### PR DESCRIPTION
Just some chores like getting rid of this warning in terminal each time you run e2e tests: 

```shell
WARN[0000] /home/kasir/projects/nestjs-query/examples/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

Typed jest conf file for better dev exp when you need to modify it.

Some typos that where here an there.

BTW I also like to ask @TriPSs why he has increased the `printWidth` of prettier to 130! I mean the recommended length is 70. So if your OK with it I am gonna change it to 70. TBH it is really long and hard to make sense of a lot of stuff. But I am also open to not touch it since it is growing on me too (as of lately I feel more comfortable around it :sweat_smile:).

One thing that bothers me though is that if I save `docker-compose.yml` or any `JSON` conf file my IDE format it and I was thinking if possible either override them in `.prettierrc` or decrease the `printWidth` to 70 since the only configuration that causes VSCode to format them in my case.