### PR TITLE
🐛 Mongoose ReferenceQueryService only accepted Relations with ObjectIds

### DIFF
--- a/packages/query-mongoose/src/services/reference-query.service.ts
+++ b/packages/query-mongoose/src/services/reference-query.service.ts
@@ -195,8 +195,8 @@ export abstract class ReferenceQueryService<Entity extends Document> {
       const refs = entityRelations.filter((er) => {
         return referenceIds.some((rid) => {
           const oneOrManyIds = er[refFieldMap.foreignField as keyof Relation]
-          const ids = (Array.isArray(oneOrManyIds) ? oneOrManyIds : [oneOrManyIds]) as Types.ObjectId[]
-          return ids.some((id) => id.equals(rid as Types.ObjectId))
+          const ids = Array.isArray(oneOrManyIds) ? oneOrManyIds : [oneOrManyIds]
+          return ids.some((id) => String(id) === String(rid))
         })
       })
       results.set(dto, await assembler.convertToDTOs(refs))


### PR DESCRIPTION
There is a hard limitation in `ReferenceQueryService` that can only handle Relations/UnpagedRelations when the id fields are of type `ObjectId`. Since you can make relations with all kinds of field types in mongoose, nestjs-query should also support it. 