### PR TITLE
🐛 mongoose ilike comparism could not search with fixed start/end letter

### DIFF
--- a/packages/query-mongoose/__tests__/query/comparison.builder.spec.ts
+++ b/packages/query-mongoose/__tests__/query/comparison.builder.spec.ts
@@ -73,7 +73,7 @@ describe('ComparisonBuilder', (): void => {
   it('should build like sql fragment', (): void => {
     expect(createComparisonBuilder().build('stringType', 'like', '%hello%')).toEqual({
       stringType: {
-        $regex: /.*hello.*/
+        $regex: /^.*hello.*$/
       }
     })
   })
@@ -81,7 +81,7 @@ describe('ComparisonBuilder', (): void => {
   it('should build notLike sql fragment', (): void => {
     expect(createComparisonBuilder().build('stringType', 'notLike', '%hello%')).toEqual({
       stringType: {
-        $not: { $regex: /.*hello.*/ }
+        $not: { $regex: /^.*hello.*$/ }
       }
     })
   })
@@ -89,7 +89,7 @@ describe('ComparisonBuilder', (): void => {
   it('should build iLike sql fragment', (): void => {
     expect(createComparisonBuilder().build('stringType', 'iLike', '%hello%')).toEqual({
       stringType: {
-        $regex: /.*hello.*/i
+        $regex: /^.*hello.*$/i
       }
     })
   })
@@ -97,7 +97,7 @@ describe('ComparisonBuilder', (): void => {
   it('should build notILike sql fragment', (): void => {
     expect(createComparisonBuilder().build('stringType', 'notILike', '%hello%')).toEqual({
       stringType: {
-        $not: { $regex: /.*hello.*/i }
+        $not: { $regex: /^.*hello.*$/i }
       }
     })
   })

--- a/packages/query-mongoose/__tests__/query/where.builder.spec.ts
+++ b/packages/query-mongoose/__tests__/query/where.builder.spec.ts
@@ -54,7 +54,7 @@ describe('WhereBuilder', (): void => {
       {
         $and: [
           {
-            $and: [{ numberType: { $eq: 1 } }, { stringType: { $regex: /foo.*/ } }, { boolType: { $eq: true } }]
+            $and: [{ numberType: { $eq: 1 } }, { stringType: { $regex: /^foo.*$/ } }, { boolType: { $eq: true } }]
           }
         ]
       }
@@ -88,8 +88,8 @@ describe('WhereBuilder', (): void => {
         },
         {
           $and: [
-            { $and: [{ $and: [{ numberType: { $gt: 10 } }, { stringType: { $regex: /foo.*/ } }] }] },
-            { $and: [{ $and: [{ numberType: { $lt: 20 } }, { stringType: { $regex: /.*bar/ } }] }] }
+            { $and: [{ $and: [{ numberType: { $gt: 10 } }, { stringType: { $regex: /^foo.*$/ } }] }] },
+            { $and: [{ $and: [{ numberType: { $lt: 20 } }, { stringType: { $regex: /^.*bar$/ } }] }] }
           ]
         }
       )
@@ -147,14 +147,14 @@ describe('WhereBuilder', (): void => {
             {
               $and: [
                 {
-                  $and: [{ numberType: { $gt: 10 } }, { stringType: { $regex: /foo.*/ } }]
+                  $and: [{ numberType: { $gt: 10 } }, { stringType: { $regex: /^foo.*$/ } }]
                 }
               ]
             },
             {
               $and: [
                 {
-                  $and: [{ numberType: { $lt: 20 } }, { stringType: { $regex: /.*bar/ } }]
+                  $and: [{ numberType: { $lt: 20 } }, { stringType: { $regex: /^.*bar$/ } }]
                 }
               ]
             }

--- a/packages/query-mongoose/src/query/comparison.builder.ts
+++ b/packages/query-mongoose/src/query/comparison.builder.ts
@@ -98,7 +98,7 @@ export class ComparisonBuilder<Entity extends Document> {
 
   private likeComparison<F extends keyof Entity>(cmp: string, val: EntityComparisonField<Entity, F>): FilterQuery<RegExp> {
     const regExpStr = escapeRegExp(`${String(val)}`).replace(/%/g, '.*')
-    const regExp = new RegExp(regExpStr, cmp.includes('ilike') ? 'i' : undefined)
+    const regExp = new RegExp(`^${regExpStr}$`, cmp.includes('ilike') ? 'i' : undefined)
 
     if (cmp.startsWith('not')) {
       return { $not: { $regex: regExp } }


### PR DESCRIPTION


this PR fixes misbehaviour described in https://github.com/TriPSs/nestjs-query/issues/298