### PR TITLE
(graphql): Update ts-morph peer dependency versions to prevent error on install

### DIFF
--- a/packages/query-graphql/package.json
+++ b/packages/query-graphql/package.json
@@ -44,7 +44,7 @@
     "class-validator": "^0.14.0",
     "graphql": "^16.0.0",
     "graphql-subscriptions": "^3.0.0",
-    "ts-morph": "^19.0.0"
+    "ts-morph": "^19.0.0 || ^20.0.0 || ^21.0.0 || ^24.0.0 || ^25.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Update package.json to add more allowed versions of ts-morph peer dependency versions to prevent error on install