### PR TITLE
feat(typegoose,mongoose)!: support Typegoose 13 and Mongoose 9

### DIFF
--- a/examples/mongoose/src/tag/tag.entity.ts
+++ b/examples/mongoose/src/tag/tag.entity.ts
@@ -7,6 +7,8 @@ export class TagEntity extends Document {
   @ObjectId()
   _id: mongoose.Types.ObjectId
 
+  id!: string
+
   @Prop({ required: true })
   name!: string
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@apollo/subgraph": "2.14.1"
   },
   "dependencies": {
-    "@m8a/nestjs-typegoose": "12.0.1",
+    "@m8a/nestjs-typegoose": "13.0.0",
     "@nestjs/common": "11.1.26",
     "@nestjs/core": "11.1.26",
     "@nestjs/graphql": "^13.4.2",
@@ -28,7 +28,7 @@
     "@nestjs/sequelize": "11.0.1",
     "@nestjs/typeorm": "^11.0.1",
     "class-validator": "0.15.1",
-    "mongoose": "8.22.1",
+    "mongoose": "9.6.3",
     "reflect-metadata": "^0.2.2",
     "sequelize": "6.37.8",
     "sequelize-typescript": "2.1.6",
@@ -61,7 +61,7 @@
     "@nx/jest": "22.7.5",
     "@nx/js": "22.7.5",
     "@nx/node": "22.7.5",
-    "@typegoose/typegoose": "12.21.1",
+    "@typegoose/typegoose": "13.3.0",
     "@types/express": "4.17.25",
     "@types/jest": "30.0.0",
     "@types/lodash.escaperegexp": "4.1.9",

--- a/packages/query-mongoose/__tests__/__fixtures__/test-reference.entity.ts
+++ b/packages/query-mongoose/__tests__/__fixtures__/test-reference.entity.ts
@@ -3,6 +3,9 @@ import { Document, SchemaTypes, Types } from 'mongoose'
 
 @Schema()
 export class TestReference extends Document<any> {
+  // Mongoose 9's `Document<any>` no longer surfaces the `id` virtual on the type; declare it for tests.
+  declare id: string
+
   @Prop({ required: true })
   referenceName!: string
 

--- a/packages/query-mongoose/__tests__/__fixtures__/test.entity.ts
+++ b/packages/query-mongoose/__tests__/__fixtures__/test.entity.ts
@@ -3,6 +3,9 @@ import { Document, SchemaTypes, Types } from 'mongoose'
 
 @Schema()
 export class TestEntity extends Document<any> {
+  // Mongoose 9's `Document<any>` no longer surfaces the `id` virtual on the type; declare it for tests.
+  declare id: string
+
   @Prop({ required: true })
   stringType!: string
 

--- a/packages/query-mongoose/__tests__/query/where.builder.spec.ts
+++ b/packages/query-mongoose/__tests__/query/where.builder.spec.ts
@@ -3,7 +3,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
 import { Filter } from '@ptc-org/nestjs-query-core'
 import { FilterableField, FilterType } from '@ptc-org/nestjs-query-graphql'
 import { plainToClass } from 'class-transformer'
-import { Document, FilterQuery, model } from 'mongoose'
+import { Document, QueryFilter, model } from 'mongoose'
 
 import { WhereBuilder } from '../../src/query'
 import { TestEntity, TestEntitySchema } from '../__fixtures__/test.entity'
@@ -11,12 +11,13 @@ import { TestEntity, TestEntitySchema } from '../__fixtures__/test.entity'
 describe('WhereBuilder', (): void => {
   const createWhereBuilder = () => new WhereBuilder<TestEntity>(model('TestEntity', TestEntitySchema))
 
-  const expectFilter = <T = TestEntity>(
+  const expectFilter = <T extends Document<any> = TestEntity>(
     filter: Filter<T>,
-    expectedFilterQuery: FilterQuery<T>,
-    whereBuilder?: WhereBuilder<Document<any>>
+    expectedFilterQuery: QueryFilter<T>,
+    whereBuilder?: WhereBuilder<T>
   ): void => {
-    const actual = (whereBuilder ?? createWhereBuilder()).build(filter)
+    const builder = (whereBuilder ?? createWhereBuilder()) as WhereBuilder<T>
+    const actual = builder.build(filter)
     expect(actual).toEqual(expectedFilterQuery)
   }
 
@@ -25,7 +26,7 @@ describe('WhereBuilder', (): void => {
   })
 
   it('or multiple operators for a single field together', (): void => {
-    expectFilter(
+    expectFilter<TestEntity>(
       {
         numberType: { gt: 10, lt: 20, gte: 21, lte: 31 }
       },
@@ -119,7 +120,7 @@ describe('WhereBuilder', (): void => {
 
   describe('or', (): void => {
     it('or multiple expressions together', (): void => {
-      expectFilter(
+      expectFilter<TestEntity>(
         {
           or: [{ numberType: { gt: 10 } }, { numberType: { lt: 20 } }, { numberType: { gte: 30 } }, { numberType: { lte: 40 } }]
         },

--- a/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
+++ b/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
@@ -861,7 +861,7 @@ describe('MongooseQueryService', () => {
       })
 
       it('should return an empty array if no results are found.', async () => {
-        const entities: TestEntity[] = [TEST_ENTITIES[0], { id: new Types.ObjectId() } as TestEntity]
+        const entities: TestEntity[] = [TEST_ENTITIES[0], { id: new Types.ObjectId() as never as string } as TestEntity]
         const queryService = moduleRef.get(TestEntityService)
         const queryResult = await queryService.queryRelations(TestReference, 'testReferences', entities, {
           filter: { referenceName: { isNot: null } }

--- a/packages/query-mongoose/package.json
+++ b/packages/query-mongoose/package.json
@@ -30,8 +30,8 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@nestjs/mongoose": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "mongoose": "^8.0.0"
+    "@nestjs/mongoose": "^11.0.0",
+    "mongoose": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/query-mongoose/src/mongoose-types.helper.ts
+++ b/packages/query-mongoose/src/mongoose-types.helper.ts
@@ -29,13 +29,19 @@ export function isSchemaTypeWithReferenceOptions(type: unknown): type is SchemaT
 }
 
 export type EmbeddedSchemaTypeOptions = {
-  $embeddedSchemaType: { options: ReferenceOptions }
+  // Mongoose 9 renamed the array element accessor `$embeddedSchemaType` to `embeddedSchemaType`; support both.
+  $embeddedSchemaType?: { options: ReferenceOptions }
+  embeddedSchemaType?: { options: ReferenceOptions }
+}
+
+export function getEmbeddedSchemaType(schemaType: EmbeddedSchemaTypeOptions): { options: ReferenceOptions } | undefined {
+  return schemaType.embeddedSchemaType ?? schemaType.$embeddedSchemaType
 }
 
 export function isEmbeddedSchemaTypeOptions(options: unknown): options is EmbeddedSchemaTypeOptions {
-  if (options && typeof options === 'object' && '$embeddedSchemaType' in options) {
-    const { $embeddedSchemaType } = options as { $embeddedSchemaType: { options: unknown } }
-    return isReferenceOptions($embeddedSchemaType.options)
+  if (options && typeof options === 'object' && ('embeddedSchemaType' in options || '$embeddedSchemaType' in options)) {
+    const embedded = getEmbeddedSchemaType(options as EmbeddedSchemaTypeOptions)
+    return !!embedded && isReferenceOptions(embedded.options)
   }
   return false
 }

--- a/packages/query-mongoose/src/query/comparison.builder.ts
+++ b/packages/query-mongoose/src/query/comparison.builder.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common'
 import { CommonFieldComparisonBetweenType, FilterComparisonOperators } from '@ptc-org/nestjs-query-core'
 import escapeRegExp from 'lodash.escaperegexp'
-import { Document, FilterQuery, Model as MongooseModel, Schema, Types } from 'mongoose'
+import { Document, QueryFilter, Model as MongooseModel, Schema, Types } from 'mongoose'
 
 import { getSchemaKey } from './helpers'
 
@@ -50,15 +50,15 @@ export class ComparisonBuilder<Entity extends Document<any>> {
     field: F,
     cmp: FilterComparisonOperators<Entity[F]>,
     val: EntityComparisonField<Entity, F>
-  ): FilterQuery<Entity> {
+  ): QueryFilter<Entity> {
     const schemaKey = getSchemaKey(`${String(field)}`)
     const normalizedCmp = (cmp as string).toLowerCase()
-    let querySelector: FilterQuery<Entity[F]> | undefined
+    let querySelector: QueryFilter<Entity[F]> | undefined
     if (this.comparisonMap[normalizedCmp]) {
       // comparison operator (e.b. =, !=, >, <)
       querySelector = {
         [this.comparisonMap[normalizedCmp]]: this.convertQueryValue(field, val as Entity[F])
-      } as FilterQuery<Entity[F]>
+      } as QueryFilter<Entity[F]>
     }
 
     if (normalizedCmp.includes('like')) {
@@ -73,14 +73,14 @@ export class ComparisonBuilder<Entity extends Document<any>> {
       throw new BadRequestException(`unknown operator ${JSON.stringify(cmp)}`)
     }
 
-    return { [schemaKey]: querySelector } as FilterQuery<Entity>
+    return { [schemaKey]: querySelector } as QueryFilter<Entity>
   }
 
   private betweenComparison<F extends keyof Entity>(
     cmp: string,
     field: F,
     val: EntityComparisonField<Entity, F>
-  ): FilterQuery<Entity[F]> {
+  ): QueryFilter<Entity[F]> {
     if (!this.isBetweenVal(val)) {
       throw new Error(`Invalid value for ${cmp} expected {lower: val, upper: val} got ${JSON.stringify(val)}`)
     }
@@ -96,7 +96,7 @@ export class ComparisonBuilder<Entity extends Document<any>> {
     return val !== null && typeof val === 'object' && 'lower' in val && 'upper' in val
   }
 
-  private likeComparison<F extends keyof Entity>(cmp: string, val: EntityComparisonField<Entity, F>): FilterQuery<RegExp> {
+  private likeComparison<F extends keyof Entity>(cmp: string, val: EntityComparisonField<Entity, F>): QueryFilter<RegExp> {
     const regExpStr = escapeRegExp(`${String(val)}`).replace(/%/g, '.*')
     const regExp = new RegExp(`^${regExpStr}$`, cmp.includes('ilike') ? 'i' : undefined)
 
@@ -123,8 +123,11 @@ export class ComparisonBuilder<Entity extends Document<any>> {
       return val.map((v) => this.convertToObjectId(v))
     }
     if (typeof val === 'string' || typeof val === 'number') {
-      if (Types.ObjectId.isValid(val)) {
-        return new Types.ObjectId(val)
+      // Mongoose 9 narrowed ObjectId's accepted input types to exclude `number`;
+      // the runtime still accepts it, so assert to satisfy the compiler without changing behavior.
+      const idVal = val as string
+      if (Types.ObjectId.isValid(idVal)) {
+        return new Types.ObjectId(idVal)
       }
     }
     return val

--- a/packages/query-mongoose/src/query/comparison.builder.ts
+++ b/packages/query-mongoose/src/query/comparison.builder.ts
@@ -108,7 +108,8 @@ export class ComparisonBuilder<Entity extends Document<any>> {
   }
 
   private convertQueryValue<F extends keyof Entity>(field: F, val: Entity[F]): Entity[F] {
-    const schemaType = this.Model.schema.path(getSchemaKey(field as string))
+    const schema = this.Model.schema as Schema<Entity>
+    const schemaType = schema.path(getSchemaKey(field as string))
     if (!schemaType) {
       throw new BadRequestException(`unknown comparison field ${String(field)}`)
     }

--- a/packages/query-mongoose/src/query/filter-query.builder.ts
+++ b/packages/query-mongoose/src/query/filter-query.builder.ts
@@ -1,5 +1,5 @@
 import { AggregateQuery, Filter, Query, SortDirection, SortField } from '@ptc-org/nestjs-query-core'
-import { Document, FilterQuery, Model as MongooseModel } from 'mongoose'
+import { Document, QueryFilter, Model as MongooseModel } from 'mongoose'
 
 import { AggregateBuilder, MongooseGroupAndAggregate } from './aggregate.builder'
 import { getSchemaKey } from './helpers'
@@ -12,7 +12,7 @@ const MONGOOSE_SORT_DIRECTION: Record<SortDirection, 1 | -1> = {
 
 type MongooseSort = Record<string, 1 | -1>
 type MongooseQuery<Entity extends Document<any>> = {
-  filterQuery: FilterQuery<Entity>
+  filterQuery: QueryFilter<Entity>
   options: { limit?: number; skip?: number; sort?: MongooseSort }
 }
 
@@ -59,7 +59,7 @@ export class FilterQueryBuilder<Entity extends Document<any>> {
     }
   }
 
-  public buildIdFilterQuery(id: unknown, filter?: Filter<Entity>): FilterQuery<Entity> {
+  public buildIdFilterQuery(id: unknown, filter?: Filter<Entity>): QueryFilter<Entity> {
     return {
       ...this.buildFilterQuery(filter),
       _id: Array.isArray(id) ? { $in: id } : id
@@ -71,7 +71,7 @@ export class FilterQueryBuilder<Entity extends Document<any>> {
    *
    * @param filter - the filter.
    */
-  public buildFilterQuery(filter?: Filter<Entity>): FilterQuery<Entity> {
+  public buildFilterQuery(filter?: Filter<Entity>): QueryFilter<Entity> {
     if (!filter) {
       return {}
     }

--- a/packages/query-mongoose/src/query/where.builder.ts
+++ b/packages/query-mongoose/src/query/where.builder.ts
@@ -1,5 +1,5 @@
 import { Filter, FilterComparisons, FilterFieldComparison } from '@ptc-org/nestjs-query-core'
-import { Document, FilterQuery, Model as MongooseModel } from 'mongoose'
+import { Document, QueryFilter, Model as MongooseModel } from 'mongoose'
 
 import { ComparisonBuilder, EntityComparisonField } from './comparison.builder'
 
@@ -17,12 +17,12 @@ export class WhereBuilder<Entity extends Document<any>> {
    * Builds a WHERE clause from a Filter.
    * @param filter - the filter to build the WHERE clause from.
    */
-  build(filter: Filter<Entity>): FilterQuery<Entity> {
+  build(filter: Filter<Entity>): QueryFilter<Entity> {
     const normalizedFilter = this.getNormalizedFilter(filter)
     const { and, or } = normalizedFilter
-    let ands: FilterQuery<Entity>[] = []
-    let ors: FilterQuery<Entity>[] = []
-    let filterQuery: FilterQuery<Entity> = {}
+    let ands: QueryFilter<Entity>[] = []
+    let ors: QueryFilter<Entity>[] = []
+    let filterQuery: QueryFilter<Entity> = {}
     if (and && and.length) {
       ands = and.map((f) => this.build(f))
     }
@@ -34,10 +34,10 @@ export class WhereBuilder<Entity extends Document<any>> {
       ands = [...ands, filterAnds]
     }
     if (ands.length) {
-      filterQuery = { ...filterQuery, $and: ands } as FilterQuery<Entity>
+      filterQuery = { ...filterQuery, $and: ands } as QueryFilter<Entity>
     }
     if (ors.length) {
-      filterQuery = { ...filterQuery, $or: ors } as FilterQuery<Entity>
+      filterQuery = { ...filterQuery, $or: ors } as QueryFilter<Entity>
     }
     return filterQuery
   }
@@ -78,7 +78,7 @@ export class WhereBuilder<Entity extends Document<any>> {
    * Creates field comparisons from a filter. This method will ignore and/or properties.
    * @param filter - the filter with fields to create comparisons for.
    */
-  private filterFields(filter: Filter<Entity>): FilterQuery<Entity> | undefined {
+  private filterFields(filter: Filter<Entity>): QueryFilter<Entity> | undefined {
     const ands = Object.keys(filter)
       .filter((f) => f !== 'and' && f !== 'or')
       .map((field) => this.withFilterComparison(field as keyof Entity, this.getField(filter, field as keyof Entity)))
@@ -86,7 +86,7 @@ export class WhereBuilder<Entity extends Document<any>> {
       return ands[0]
     }
     if (ands.length) {
-      return { $and: ands } as FilterQuery<Entity>
+      return { $and: ands } as QueryFilter<Entity>
     }
     return undefined
   }
@@ -98,7 +98,7 @@ export class WhereBuilder<Entity extends Document<any>> {
     return obj[field] as FilterFieldComparison<Entity[K]>
   }
 
-  private withFilterComparison<T extends keyof Entity>(field: T, cmp: FilterFieldComparison<Entity[T]>): FilterQuery<Entity> {
+  private withFilterComparison<T extends keyof Entity>(field: T, cmp: FilterFieldComparison<Entity[T]>): QueryFilter<Entity> {
     const opts = Object.keys(cmp) as (keyof FilterFieldComparison<Entity[T]>)[]
     if (opts.length === 1) {
       const cmpType = opts[0]
@@ -106,6 +106,6 @@ export class WhereBuilder<Entity extends Document<any>> {
     }
     return {
       $or: opts.map((cmpType) => this.comparisonBuilder.build(field, cmpType, cmp[cmpType] as EntityComparisonField<Entity, T>))
-    } as FilterQuery<Entity>
+    } as QueryFilter<Entity>
   }
 }

--- a/packages/query-mongoose/src/services/mongoose-query.service.ts
+++ b/packages/query-mongoose/src/services/mongoose-query.service.ts
@@ -135,7 +135,7 @@ export class MongooseQueryService<Entity extends Document<any>>
    */
   async createOne(record: DeepPartial<Entity>): Promise<Entity> {
     this.ensureIdIsNotPresent(record)
-    return this.Model.create(record)
+    return this.Model.create(record as Partial<Entity>)
   }
 
   /**
@@ -152,7 +152,7 @@ export class MongooseQueryService<Entity extends Document<any>>
    */
   public async createMany(records: DeepPartial<Entity>[]): Promise<Entity[]> {
     records.forEach((r) => this.ensureIdIsNotPresent(r))
-    return this.Model.create(records)
+    return this.Model.create(records as Partial<Entity>[])
   }
 
   /**

--- a/packages/query-mongoose/src/services/reference-query.service.ts
+++ b/packages/query-mongoose/src/services/reference-query.service.ts
@@ -14,6 +14,7 @@ import {
 import { Document, Model as MongooseModel, PipelineStage, Types, UpdateQuery } from 'mongoose'
 
 import {
+  getEmbeddedSchemaType,
   isEmbeddedSchemaTypeOptions,
   isSchemaTypeWithReferenceOptions,
   isVirtualTypeWithReferenceOptions,
@@ -131,7 +132,7 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
       return this.batchFindRelations(RelationClass, relationName, dto, opts)
     }
 
-    const foundEntity = await this.Model.findById(dto._id ?? dto.id)
+    const foundEntity = await this.Model.findById(dto._id ?? (dto as { id?: unknown }).id)
     if (!foundEntity) {
       return undefined
     }
@@ -308,7 +309,7 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
     if (Array.isArray(dto)) {
       return this.batchQueryRelations(RelationClass, relationName, dto, query)
     }
-    const foundEntity = await this.Model.findById(dto._id ?? dto.id)
+    const foundEntity = await this.Model.findById(dto._id ?? (dto as { id?: unknown }).id)
     if (!foundEntity) {
       return []
     }
@@ -445,7 +446,7 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
     if (this.isReferencePath(refName)) {
       const schemaType = this.Model.schema.path(refName)
       if (isEmbeddedSchemaTypeOptions(schemaType)) {
-        return db.model<Ref>(schemaType.$embeddedSchemaType.options.ref)
+        return db.model<Ref>(getEmbeddedSchemaType(schemaType)!.options.ref)
       }
       if (isSchemaTypeWithReferenceOptions(schemaType)) {
         return db.model<Ref>(schemaType.options.ref)

--- a/packages/query-mongoose/src/services/reference-query.service.ts
+++ b/packages/query-mongoose/src/services/reference-query.service.ts
@@ -11,7 +11,7 @@ import {
   ModifyRelationOptions,
   Query
 } from '@ptc-org/nestjs-query-core'
-import { Document, Model as MongooseModel, PipelineStage, Types, UpdateQuery } from 'mongoose'
+import { Document, Model as MongooseModel, PipelineStage, Schema, Types, UpdateQuery } from 'mongoose'
 
 import {
   getEmbeddedSchemaType,
@@ -429,12 +429,16 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
     throw new Error(`Unable to find reference ${refName} on ${this.Model.modelName}`)
   }
 
+  private get schema(): Schema<Entity> {
+    return this.Model.schema as Schema<Entity>
+  }
+
   private isReferencePath(refName: string): boolean {
-    return !!this.Model.schema.path(refName)
+    return !!this.schema.path(refName)
   }
 
   private isVirtualPath(refName: string): boolean {
-    return !!this.Model.schema.virtualpath(refName)
+    return !!this.schema.virtualpath(refName)
   }
 
   private getReferenceQueryBuilder<Ref extends Document<any>>(refName: string): FilterQueryBuilder<Ref> {
@@ -444,15 +448,18 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
   private getReferenceModel<Ref extends Document<any>>(refName: string): MongooseModel<Ref> {
     const { db } = this.Model
     if (this.isReferencePath(refName)) {
-      const schemaType = this.Model.schema.path(refName)
+      const schemaType = this.schema.path(refName)
       if (isEmbeddedSchemaTypeOptions(schemaType)) {
-        return db.model<Ref>(getEmbeddedSchemaType(schemaType)!.options.ref)
+        const embedded = getEmbeddedSchemaType(schemaType)
+        if (embedded) {
+          return db.model<Ref>(embedded.options.ref)
+        }
       }
       if (isSchemaTypeWithReferenceOptions(schemaType)) {
         return db.model<Ref>(schemaType.options.ref)
       }
     } else if (this.isVirtualPath(refName)) {
-      const schemaType = this.Model.schema.virtualpath(refName)
+      const schemaType = this.schema.virtualpath(refName)
       if (isVirtualTypeWithReferenceOptions(schemaType)) {
         return db.model<Ref>(schemaType.options.ref)
       }
@@ -491,7 +498,7 @@ export abstract class ReferenceQueryService<Entity extends Document<any>> {
       }
     }
     if (this.isVirtualPath(refName)) {
-      const virtualType = this.Model.schema.virtualpath(refName)
+      const virtualType = this.schema.virtualpath(refName)
       if (!isVirtualTypeWithReferenceOptions(virtualType)) {
         throw new Error(`Unable to lookup reference type for ${refName}`)
       }

--- a/packages/query-typegoose/__tests__/query/where.builder.spec.ts
+++ b/packages/query-typegoose/__tests__/query/where.builder.spec.ts
@@ -12,7 +12,7 @@ describe('WhereBuilder', (): void => {
 
   const expectFilterQuery = <T = TestEntity>(
     filter: Filter<T>,
-    expectedFilterQuery: mongoose.FilterQuery<T>,
+    expectedFilterQuery: mongoose.QueryFilter<T>,
     whereBuilder?: WhereBuilder<T>
   ): void => {
     const actual = (whereBuilder ?? createWhereBuilder()).build(filter)
@@ -24,7 +24,7 @@ describe('WhereBuilder', (): void => {
   })
 
   it('or multiple operators for a single field together', (): void => {
-    expectFilterQuery(
+    expectFilterQuery<TestEntity>(
       {
         numberType: { gt: 10, lt: 20, gte: 21, lte: 31 }
       },
@@ -62,7 +62,7 @@ describe('WhereBuilder', (): void => {
 
   describe('and', (): void => {
     it('and multiple expressions together', (): void => {
-      expectFilterQuery(
+      expectFilterQuery<TestEntity>(
         {
           and: [{ numberType: { gt: 10 } }, { numberType: { lt: 20 } }, { numberType: { gte: 30 } }, { numberType: { lte: 40 } }]
         },

--- a/packages/query-typegoose/package.json
+++ b/packages/query-typegoose/package.json
@@ -30,10 +30,10 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@m8a/nestjs-typegoose": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@m8a/nestjs-typegoose": "^13.0.0",
     "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@typegoose/typegoose": "^9.0.0 || ^10.0.0 || ^11.0.0",
-    "mongoose": "^6.5.0 || ^7.0.3 || ^8.0.0"
+    "@typegoose/typegoose": "^13.0.0",
+    "mongoose": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/query-typegoose/src/providers.ts
+++ b/packages/query-typegoose/src/providers.ts
@@ -43,7 +43,6 @@ function createTypegooseQueryServiceProvider<Entity extends Base>(
     provide: getQueryServiceToken({ name: modelName }),
     useFactory(ModelClass: ReturnModelType<new () => Entity>) {
       // initialize default serializer for documents, this is the type that mongoose returns from queries
-      // @ts-expect-error linting issue, tests still pass
       AssemblerSerializer((obj: DocumentType<unknown>) => obj.toObject({ virtuals: true }))(ModelClass)
 
       return new TypegooseQueryService(ModelClass)

--- a/packages/query-typegoose/src/query/comparison.builder.ts
+++ b/packages/query-typegoose/src/query/comparison.builder.ts
@@ -51,15 +51,15 @@ export class ComparisonBuilder<Entity> {
     field: F,
     cmp: FilterComparisonOperators<Entity[F]>,
     val: EntityComparisonField<Entity, F>
-  ): mongoose.FilterQuery<Entity> {
+  ): mongoose.QueryFilter<Entity> {
     const schemaKey = getSchemaKey(`${String(field)}`)
     const normalizedCmp = (cmp as string).toLowerCase()
-    let querySelector: mongoose.FilterQuery<Entity[F]> | undefined
+    let querySelector: mongoose.QueryFilter<Entity[F]> | undefined
     if (this.comparisonMap[normalizedCmp]) {
       // comparison operator (e.b. =, !=, >, <)
       querySelector = {
         [this.comparisonMap[normalizedCmp]]: this.convertQueryValue(field, val as Entity[F])
-      } as mongoose.FilterQuery<Entity[F]>
+      } as mongoose.QueryFilter<Entity[F]>
     }
     if (normalizedCmp.includes('like')) {
       querySelector = this.likeComparison(normalizedCmp, val)
@@ -73,14 +73,14 @@ export class ComparisonBuilder<Entity> {
       throw new BadRequestException(`unknown operator ${JSON.stringify(cmp)}`)
     }
 
-    return { [schemaKey]: querySelector } as mongoose.FilterQuery<Entity>
+    return { [schemaKey]: querySelector } as mongoose.QueryFilter<Entity>
   }
 
   private betweenComparison<F extends keyof Entity>(
     cmp: string,
     field: F,
     val: EntityComparisonField<Entity, F>
-  ): mongoose.FilterQuery<Entity[F]> {
+  ): mongoose.QueryFilter<Entity[F]> {
     if (!this.isBetweenVal(val)) {
       throw new Error(`Invalid value for ${cmp} expected {lower: val, upper: val} got ${JSON.stringify(val)}`)
     }
@@ -99,7 +99,7 @@ export class ComparisonBuilder<Entity> {
   private likeComparison<F extends keyof Entity>(
     cmp: string,
     val: EntityComparisonField<Entity, F>
-  ): mongoose.FilterQuery<RegExp> {
+  ): mongoose.QueryFilter<RegExp> {
     const regExpStr = escapeRegExp(`${String(val)}`).replace(/%/g, '.*')
     const regExp = new RegExp(regExpStr, cmp.includes('ilike') ? 'i' : undefined)
     if (cmp.startsWith('not')) {
@@ -124,8 +124,11 @@ export class ComparisonBuilder<Entity> {
       return val.map((v) => this.convertToObjectId(v))
     }
     if (typeof val === 'string' || typeof val === 'number') {
-      if (mongoose.Types.ObjectId.isValid(val)) {
-        return new mongoose.Types.ObjectId(val)
+      // Mongoose 9 narrowed ObjectId's accepted input types to exclude `number`;
+      // the runtime still accepts it, so assert to satisfy the compiler without changing behavior.
+      const idVal = val as string
+      if (mongoose.Types.ObjectId.isValid(idVal)) {
+        return new mongoose.Types.ObjectId(idVal)
       }
     }
     return val

--- a/packages/query-typegoose/src/query/filter-query.builder.ts
+++ b/packages/query-typegoose/src/query/filter-query.builder.ts
@@ -13,7 +13,7 @@ const TYPEGOOSE_SORT_DIRECTION: Record<SortDirection, 1 | -1> = {
 type TypegooseSort = Record<string, 1 | -1>
 
 type TypegooseQuery<Entity> = {
-  filterQuery: mongoose.FilterQuery<new () => Entity>
+  filterQuery: mongoose.QueryFilter<Entity>
   options: { limit?: number; skip?: number; sort?: TypegooseSort }
 }
 
@@ -63,7 +63,7 @@ export class FilterQueryBuilder<Entity> {
     }
   }
 
-  public buildIdFilterQuery(id: unknown, filter?: Filter<Entity>): mongoose.FilterQuery<new () => Entity> {
+  public buildIdFilterQuery(id: unknown, filter?: Filter<Entity>): mongoose.QueryFilter<Entity> {
     return {
       ...this.buildFilterQuery(filter),
       _id: Array.isArray(id) ? { $in: id } : id
@@ -75,7 +75,7 @@ export class FilterQueryBuilder<Entity> {
    *
    * @param filter - the filter.
    */
-  public buildFilterQuery(filter?: Filter<Entity>): mongoose.FilterQuery<new () => Entity> {
+  public buildFilterQuery(filter?: Filter<Entity>): mongoose.QueryFilter<Entity> {
     if (!filter) {
       return {}
     }

--- a/packages/query-typegoose/src/query/where.builder.ts
+++ b/packages/query-typegoose/src/query/where.builder.ts
@@ -18,12 +18,12 @@ export class WhereBuilder<Entity> {
    * Builds a WHERE clause from a Filter.
    * @param filter - the filter to build the WHERE clause from.
    */
-  public build(filter: Filter<Entity>): mongoose.FilterQuery<new () => Entity> {
+  public build(filter: Filter<Entity>): mongoose.QueryFilter<Entity> {
     const normalizedFilter = this.getNormalizedFilter(filter)
     const { and, or } = normalizedFilter
-    let ands: mongoose.FilterQuery<Entity>[] = []
-    let ors: mongoose.FilterQuery<Entity>[] = []
-    let filterQuery: mongoose.FilterQuery<Entity> = {}
+    let ands: mongoose.QueryFilter<Entity>[] = []
+    let ors: mongoose.QueryFilter<Entity>[] = []
+    let filterQuery: mongoose.QueryFilter<Entity> = {}
 
     if (and && and.length) {
       ands = and.map((f) => this.build(f))
@@ -84,7 +84,7 @@ export class WhereBuilder<Entity> {
    * Creates field comparisons from a filter. This method will ignore and/or properties.
    * @param filter - the filter with fields to create comparisons for.
    */
-  private filterFields(filter: Filter<Entity>): mongoose.FilterQuery<Entity> | undefined {
+  private filterFields(filter: Filter<Entity>): mongoose.QueryFilter<Entity> | undefined {
     const ands = Object.keys(filter)
       .filter((f) => f !== 'and' && f !== 'or')
       .map((field) => this.withFilterComparison(field as keyof Entity, this.getField(filter, field as keyof Entity)))
@@ -94,7 +94,7 @@ export class WhereBuilder<Entity> {
     }
 
     if (ands.length) {
-      return { $and: ands } as mongoose.FilterQuery<Entity>
+      return { $and: ands } as mongoose.QueryFilter<Entity>
     }
 
     return undefined
@@ -110,7 +110,7 @@ export class WhereBuilder<Entity> {
   private withFilterComparison<T extends keyof Entity>(
     field: T,
     cmp: FilterFieldComparison<Entity[T]>
-  ): mongoose.FilterQuery<Entity> {
+  ): mongoose.QueryFilter<Entity> {
     const opts = Object.keys(cmp) as (keyof FilterFieldComparison<Entity[T]>)[]
     if (opts.length === 1) {
       const cmpType = opts[0]
@@ -118,6 +118,6 @@ export class WhereBuilder<Entity> {
     }
     return {
       $or: opts.map((cmpType) => this.comparisonBuilder.build(field, cmpType, cmp[cmpType] as EntityComparisonField<Entity, T>))
-    } as mongoose.FilterQuery<Entity>
+    } as mongoose.QueryFilter<Entity>
   }
 }

--- a/packages/query-typegoose/src/services/reference-query.service.ts
+++ b/packages/query-typegoose/src/services/reference-query.service.ts
@@ -18,6 +18,7 @@ import { PipelineStage } from 'mongoose'
 
 import { AggregateBuilder, FilterQueryBuilder } from '../query'
 import {
+  getEmbeddedSchemaType,
   isEmbeddedSchemaTypeOptions,
   isSchemaTypeWithReferenceOptions,
   isVirtualTypeWithReferenceOptions,
@@ -351,14 +352,14 @@ export abstract class ReferenceQueryService<Entity extends Base> {
     if (this.isReferencePath(refName)) {
       const schemaType = this.Model.schema.path(refName)
       if (isEmbeddedSchemaTypeOptions(schemaType)) {
-        refModel = getModelWithString(schemaType.$embeddedSchemaType.options.ref)
+        refModel = getModelWithString(getEmbeddedSchemaType(schemaType)!.options.ref) as ReturnModelType<Class<Ref>>
       } else if (isSchemaTypeWithReferenceOptions(schemaType)) {
-        refModel = getModelWithString(schemaType.options.ref)
+        refModel = getModelWithString(schemaType.options.ref) as ReturnModelType<Class<Ref>>
       }
     } else if (this.isVirtualPath(refName)) {
       const schemaType = this.Model.schema.virtualpath(refName)
       if (isVirtualTypeWithReferenceOptions(schemaType)) {
-        refModel = getModelWithString(schemaType.options.ref)
+        refModel = getModelWithString(schemaType.options.ref) as ReturnModelType<Class<Ref>>
       }
     }
     if (!refModel) {

--- a/packages/query-typegoose/src/services/reference-query.service.ts
+++ b/packages/query-typegoose/src/services/reference-query.service.ts
@@ -352,7 +352,10 @@ export abstract class ReferenceQueryService<Entity extends Base> {
     if (this.isReferencePath(refName)) {
       const schemaType = this.Model.schema.path(refName)
       if (isEmbeddedSchemaTypeOptions(schemaType)) {
-        refModel = getModelWithString(getEmbeddedSchemaType(schemaType)!.options.ref) as ReturnModelType<Class<Ref>>
+        const embedded = getEmbeddedSchemaType(schemaType)
+        if (embedded) {
+          refModel = getModelWithString(embedded.options.ref) as ReturnModelType<Class<Ref>>
+        }
       } else if (isSchemaTypeWithReferenceOptions(schemaType)) {
         refModel = getModelWithString(schemaType.options.ref) as ReturnModelType<Class<Ref>>
       }

--- a/packages/query-typegoose/src/services/typegoose-query-service.ts
+++ b/packages/query-typegoose/src/services/typegoose-query-service.ts
@@ -119,7 +119,7 @@ export class TypegooseQueryService<Entity extends Base> extends ReferenceQuerySe
    */
   async createOne(record: DeepPartial<Entity>): Promise<DocumentType<Entity>> {
     this.ensureIdIsNotPresent(record)
-    const doc = await this.Model.create(record)
+    const doc = await this.Model.create(record as Partial<Entity>)
     return doc
   }
 
@@ -137,7 +137,7 @@ export class TypegooseQueryService<Entity extends Base> extends ReferenceQuerySe
    */
   async createMany(records: DeepPartial<Entity>[]): Promise<DocumentType<Entity>[]> {
     records.forEach((r) => this.ensureIdIsNotPresent(r))
-    const entities = await this.Model.create(records)
+    const entities = await this.Model.create(records as Partial<Entity>[])
     return entities
   }
 

--- a/packages/query-typegoose/src/typegoose-interface.helpers.ts
+++ b/packages/query-typegoose/src/typegoose-interface.helpers.ts
@@ -1,16 +1,16 @@
-import { mongoose } from '@typegoose/typegoose'
+import type { types } from '@typegoose/typegoose'
 
-export interface TypegooseClass {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  new (...args: any[]): any
-}
+// These mirror the interfaces in `@m8a/nestjs-typegoose` so that the models passed to
+// `NestjsQueryTypegooseModule.forFeature` are assignable to `TypegooseModule.forFeature`.
+// Keep them in sync with `@m8a/nestjs-typegoose`'s `typegoose-class.interface`.
+export type TypegooseClass = types.AnyParamConstructor<unknown>
 
 export interface TypegooseClassWrapper {
   typegooseClass: TypegooseClass
 }
 
 export interface TypegooseClassWithOptions extends TypegooseClassWrapper {
-  schemaOptions?: mongoose.SchemaOptions
+  schemaOptions?: types.IModelOptions['schemaOptions']
   discriminators?: (TypegooseClass | TypegooseDiscriminator)[]
 }
 

--- a/packages/query-typegoose/src/typegoose-types.helper.ts
+++ b/packages/query-typegoose/src/typegoose-types.helper.ts
@@ -45,13 +45,19 @@ export function isSchemaTypeWithReferenceOptions(type: unknown): type is SchemaT
 }
 
 export type EmbeddedSchemaTypeOptions = {
-  $embeddedSchemaType: { options: ReferenceOptions }
+  // Mongoose 9 renamed the array element accessor `$embeddedSchemaType` to `embeddedSchemaType`; support both.
+  $embeddedSchemaType?: { options: ReferenceOptions }
+  embeddedSchemaType?: { options: ReferenceOptions }
+}
+
+export function getEmbeddedSchemaType(schemaType: EmbeddedSchemaTypeOptions): { options: ReferenceOptions } | undefined {
+  return schemaType.embeddedSchemaType ?? schemaType.$embeddedSchemaType
 }
 
 export function isEmbeddedSchemaTypeOptions(options: unknown): options is EmbeddedSchemaTypeOptions {
-  if (options && typeof options === 'object' && '$embeddedSchemaType' in options) {
-    const { $embeddedSchemaType } = options as { $embeddedSchemaType: { options: unknown } }
-    return isReferenceOptions($embeddedSchemaType.options)
+  if (options && typeof options === 'object' && ('embeddedSchemaType' in options || '$embeddedSchemaType' in options)) {
+    const embedded = getEmbeddedSchemaType(options as EmbeddedSchemaTypeOptions)
+    return !!embedded && isReferenceOptions(embedded.options)
   }
   return false
 }

--- a/packages/query-typegoose/src/typegoose-types.helper.ts
+++ b/packages/query-typegoose/src/typegoose-types.helper.ts
@@ -91,7 +91,8 @@ type CustomModelType<T, QueryHelpers = BeAnObject> = mongoose.Model<
   QueryHelpers, // query helpers
   IObjectWithTypegooseFunction, // instance methods
   BeAnyObject,
-  DocumentType<T>
+  DocumentType<T>,
+  mongoose.Schema<T> // schema type
 >
 
 export type ReturnModelType<U extends AnyParamConstructor<unknown>, QueryHelpers = BeAnObject> = CustomModelType<

--- a/yarn.lock
+++ b/yarn.lock
@@ -5634,17 +5634,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@m8a/nestjs-typegoose@npm:12.0.1":
-  version: 12.0.1
-  resolution: "@m8a/nestjs-typegoose@npm:12.0.1"
+"@m8a/nestjs-typegoose@npm:13.0.0":
+  version: 13.0.0
+  resolution: "@m8a/nestjs-typegoose@npm:13.0.0"
   dependencies:
     is-class: "npm:0.0.9"
   peerDependencies:
     "@nestjs/common": ^10.0.0 || ^11.0.0
     "@nestjs/core": ^10.0.0 || ^11.0.0
-    "@typegoose/typegoose": ^12.0.0
-    mongoose: ^8.0.1
-  checksum: 10/65fae553e4b0ae74008d210022969267a0f88e1e0532930880b54b3e47d8b7bf63ea5ea5dfd24793473df21347f784fbae1efa36d099fded650119a7087ff317
+    "@typegoose/typegoose": ^13.0.0
+    mongoose: ^9.0.0
+  checksum: 10/9d2b079097ca3566b1bba8c3db0fe4531380009068e4b5469c6f1ba7b13cd2dbd9b5a111818b991b3fb19c421448d62d4028640c0ac48bb1ad47e82bf1adab4b
   languageName: node
   linkType: hard
 
@@ -7288,8 +7288,8 @@ __metadata:
     tslib: "npm:^2.8.1"
   peerDependencies:
     "@nestjs/common": ^9.0.0 || ^10.0.0 || ^11.0.0
-    "@nestjs/mongoose": ^9.0.0 || ^10.0.0 || ^11.0.0
-    mongoose: ^8.0.0
+    "@nestjs/mongoose": ^11.0.0
+    mongoose: ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -7318,10 +7318,10 @@ __metadata:
     lodash.merge: "npm:^4.6.2"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    "@m8a/nestjs-typegoose": ^9.0.0 || ^10.0.0 || ^11.0.0
+    "@m8a/nestjs-typegoose": ^13.0.0
     "@nestjs/common": ^9.0.0 || ^10.0.0 || ^11.0.0
-    "@typegoose/typegoose": ^9.0.0 || ^10.0.0 || ^11.0.0
-    mongoose: ^6.5.0 || ^7.0.3 || ^8.0.0
+    "@typegoose/typegoose": ^13.0.0
+    mongoose: ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -7726,18 +7726,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typegoose/typegoose@npm:12.21.1":
-  version: 12.21.1
-  resolution: "@typegoose/typegoose@npm:12.21.1"
+"@typegoose/typegoose@npm:13.3.0":
+  version: 13.3.0
+  resolution: "@typegoose/typegoose@npm:13.3.0"
   dependencies:
     lodash: "npm:^4.17.20"
     loglevel: "npm:^1.9.2"
     reflect-metadata: "npm:^0.2.2"
-    semver: "npm:^7.7.2"
+    semver: "npm:^7.7.3"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    mongoose: ~8.21.0
-  checksum: 10/ed9976ffd706ede755d078c15235128c06751e75262286845f00c62d01a31ab6df102a3e3f3c85287d8a1180950921fc3c19dc20e760fb879ae7b9b0a54f6f66
+    mongoose: ~9.6.0
+  checksum: 10/f1078bf8e75adbec1104381934d20e362d6366d00b91cdc5ff16d073fcd1454b1c392d9c93aab476ce0691cb1ae14f35e46b1ae3ff70df441aa59f9849800d61
   languageName: node
   linkType: hard
 
@@ -8473,12 +8473,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/whatwg-url@npm:^11.0.2":
-  version: 11.0.5
-  resolution: "@types/whatwg-url@npm:11.0.5"
+"@types/whatwg-url@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@types/whatwg-url@npm:13.0.0"
   dependencies:
     "@types/webidl-conversions": "npm:*"
-  checksum: 10/23a0c45aff51817807b473a6adb181d6e3bb0d27dde54e84883d5d5bc93358e95204d2188e7ff7fdc2cdaf157e97e1188ef0a22ec79228da300fc30d4a05b56a
+  checksum: 10/82018c7dc057dd4b5ee6137e54a659d2d043146eaade8afc2dda472773cc66f2abad73525020a2bf399a09b1bf448504f9e519d6b2d7495e6e781bb5de686753
   languageName: node
   linkType: hard
 
@@ -10727,10 +10727,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bson@npm:^6.10.4":
-  version: 6.10.4
-  resolution: "bson@npm:6.10.4"
-  checksum: 10/8a79a452219a13898358a5abc93e32bc3805236334f962661da121ce15bd5cade27718ba3310ee2a143ff508489b08467eed172ecb2a658cb8d2e94fdb76b215
+"bson@npm:^7.2.0":
+  version: 7.3.1
+  resolution: "bson@npm:7.3.1"
+  checksum: 10/be4eb108d29a1ae9f7e4c53bddda2b8637bb7f54334a1c3ca71e45f78b11d8e8ff38b37a2e981125f31bdc2e6456070aa71c07ef3a4d4119ab48e8b49d7af584
   languageName: node
   linkType: hard
 
@@ -12340,7 +12340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.x, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -18063,10 +18063,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kareem@npm:2.6.3":
-  version: 2.6.3
-  resolution: "kareem@npm:2.6.3"
-  checksum: 10/8c2a2795b9b8537ad592d30e6a607e7db737c7401d4c178fa4f2984e7bb7444d0f185570ae0132633aeef8b3eb27d1b5fded07921661738a5723681eb6d246b4
+"kareem@npm:3.3.0":
+  version: 3.3.0
+  resolution: "kareem@npm:3.3.0"
+  checksum: 10/28fa51f594531ddf88b00e421156fd6e2b4d3c0fe069f908cc705587a2c3ba55ac90c7dbe6ffd867259b9116efcf0d3efdaab7b6a9ad711259d186c88ac18393
   languageName: node
   linkType: hard
 
@@ -19847,13 +19847,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-connection-string-url@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "mongodb-connection-string-url@npm:3.0.2"
+"mongodb-connection-string-url@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "mongodb-connection-string-url@npm:7.0.1"
   dependencies:
-    "@types/whatwg-url": "npm:^11.0.2"
-    whatwg-url: "npm:^14.1.0 || ^13.0.0"
-  checksum: 10/99ac939a67cc963b90cfe70a8e45250a8386c531be7d22ffa5d1f3e5dd2406b149fb823b91ac161e4a4a29dfac754b49bca8f6dd786cfc66ae0ca80db5f5f23d
+    "@types/whatwg-url": "npm:^13.0.0"
+    whatwg-url: "npm:^14.1.0"
+  checksum: 10/6b48e3d0674d375163613617bdecbc18860bfaa8635873cef8a2eb41cb04a317b5f541b8f732664d03c098f9937c02c3eb013289e124f6473a44ed3aa6daceee
   languageName: node
   linkType: hard
 
@@ -19919,21 +19919,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb@npm:~6.20.0":
-  version: 6.20.0
-  resolution: "mongodb@npm:6.20.0"
+"mongodb@npm:~7.2":
+  version: 7.2.0
+  resolution: "mongodb@npm:7.2.0"
   dependencies:
     "@mongodb-js/saslprep": "npm:^1.3.0"
-    bson: "npm:^6.10.4"
-    mongodb-connection-string-url: "npm:^3.0.2"
+    bson: "npm:^7.2.0"
+    mongodb-connection-string-url: "npm:^7.0.0"
   peerDependencies:
-    "@aws-sdk/credential-providers": ^3.188.0
-    "@mongodb-js/zstd": ^1.1.0 || ^2.0.0
-    gcp-metadata: ^5.2.0
-    kerberos: ^2.0.1
-    mongodb-client-encryption: ">=6.0.0 <7"
+    "@aws-sdk/credential-providers": ^3.806.0
+    "@mongodb-js/zstd": ^7.0.0
+    gcp-metadata: ^7.0.1
+    kerberos: ^7.0.0
+    mongodb-client-encryption: ">=7.0.0 <7.1.0"
     snappy: ^7.3.2
-    socks: ^2.7.1
+    socks: ^2.8.6
   peerDependenciesMeta:
     "@aws-sdk/credential-providers":
       optional: true
@@ -19949,22 +19949,21 @@ __metadata:
       optional: true
     socks:
       optional: true
-  checksum: 10/2718cdd4433bc3847f01a2ffae3a7e7ea8499035be4fccaf76278cbe3f915f2dd6c53135be0e3cc2cdd8e27a0b957da49e337d9b96b53e6287ec8971cea96b4b
+  checksum: 10/9a1df6e0a1eb072efdfad3b9c452f0a225f966e890e027efbbca9f591a2a49fa6209faadfd9dfab8ee55362d0378c8f8d2dd2837873bc6aecff6ae422b359aad
   languageName: node
   linkType: hard
 
-"mongoose@npm:8.22.1":
-  version: 8.22.1
-  resolution: "mongoose@npm:8.22.1"
+"mongoose@npm:9.6.3":
+  version: 9.6.3
+  resolution: "mongoose@npm:9.6.3"
   dependencies:
-    bson: "npm:^6.10.4"
-    kareem: "npm:2.6.3"
-    mongodb: "npm:~6.20.0"
+    kareem: "npm:3.3.0"
+    mongodb: "npm:~7.2"
     mpath: "npm:0.9.0"
-    mquery: "npm:5.0.0"
+    mquery: "npm:6.0.0"
     ms: "npm:2.1.3"
     sift: "npm:17.1.3"
-  checksum: 10/f9e63ca88b40924275264aca28f7686d45a6ebc77ec4d7ffc5aa6cd1da979bd6a0d4ff87c948fa96f789bd80189e368c897c165a817667b1d82c67c199802489
+  checksum: 10/fd5c0b2bf6e14be267ee18ba5a65ec994288cc2d5916012cb7348f46983ed992309a4736c1e6ccdc4d9a8d7491c9c7f1bc46a7a908d5a9e2d960871e436d68fd
   languageName: node
   linkType: hard
 
@@ -19982,12 +19981,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mquery@npm:5.0.0":
-  version: 5.0.0
-  resolution: "mquery@npm:5.0.0"
-  dependencies:
-    debug: "npm:4.x"
-  checksum: 10/36a792b2dc3fae92be0a7460151807fbbefe1299f8f286acd74968482e0dc042321c78ad76d6f975f0638370ff88df6e81db5efe17df5d53d2fb289cedbb0c23
+"mquery@npm:6.0.0":
+  version: 6.0.0
+  resolution: "mquery@npm:6.0.0"
+  checksum: 10/79f0f8361f701e422fb7f179c0bf3d1c0a22d4da9893b6aa1e09e331455c18ad4c6023909c2ad9a6a23d9be0e634fef9790eaffe0c461543a1338e1d7b9a4a83
   languageName: node
   linkType: hard
 
@@ -20177,7 +20174,7 @@ __metadata:
     "@docusaurus/module-type-aliases": "npm:3.10.1"
     "@docusaurus/preset-classic": "npm:3.10.1"
     "@jscutlery/semver": "npm:6.1.2"
-    "@m8a/nestjs-typegoose": "npm:12.0.1"
+    "@m8a/nestjs-typegoose": "npm:13.0.0"
     "@mikro-orm/better-sqlite": "npm:^6.6.14"
     "@mikro-orm/core": "npm:^6.6.14"
     "@mikro-orm/nestjs": "npm:^6.1.2"
@@ -20200,7 +20197,7 @@ __metadata:
     "@nx/jest": "npm:22.7.5"
     "@nx/js": "npm:22.7.5"
     "@nx/node": "npm:22.7.5"
-    "@typegoose/typegoose": "npm:12.21.1"
+    "@typegoose/typegoose": "npm:13.3.0"
     "@types/express": "npm:4.17.25"
     "@types/jest": "npm:30.0.0"
     "@types/lodash.escaperegexp": "npm:4.1.9"
@@ -20242,7 +20239,7 @@ __metadata:
     jest-extended: "npm:7.0.0"
     jest-util: "npm:30.0.5"
     mongodb-memory-server: "npm:9.5.0"
-    mongoose: "npm:8.22.1"
+    mongoose: "npm:9.6.3"
     mysql2: "npm:3.22.5"
     nx: "npm:22.7.5"
     passport: "npm:0.7.0"
@@ -26805,7 +26802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^14.1.0 || ^13.0.0":
+"whatwg-url@npm:^14.1.0":
   version: 14.2.0
   resolution: "whatwg-url@npm:14.2.0"
   dependencies:


### PR DESCRIPTION
Migrate query-typegoose and query-mongoose to Typegoose 13 / Mongoose 9.

Mongoose 9 renamed several public types and a schema-path accessor, so the adapters no longer compile or run against it unchanged:

- `FilterQuery<T>` renamed to `QueryFilter<T>` (namespace + named import)
- array-reference schema paths renamed `$embeddedSchemaType` -> `embeddedSchemaType`; resolved via a `getEmbeddedSchemaType` accessor that reads whichever name is present, so the type guards keep working on both Mongoose 8 and 9. This was the cause of all relation-resolution failures.
- `Model.create` overloads tightened -> create args cast to `Partial<Entity>`
- `ObjectId`/`isValid` dropped `number` from accepted input types
- `Document<any>` no longer surfaces the `id` virtual on the type

Also corrects a latent bug where the filter builders were annotated `QueryFilter<new () => Entity>` (a constructor type) instead of `QueryFilter<Entity>`; Mongoose 8's looser typing had hidden it.

Peers: query-typegoose -> @typegoose/typegoose ^13, @m8a/nestjs-typegoose ^13, mongoose ^9; query-mongoose -> mongoose ^9, @nestjs/mongoose ^11. Because Mongoose renamed the core filter type, the same source cannot compile against both Mongoose 8 and 9, so this is a breaking change for the adapters.

Tests pass against Typegoose 13.3.0 / Mongoose 9.6.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency ranges to align with Mongoose 9 and Typegoose 13 across the packages.
* **Refactor**
  * Migrated query typing to the newer `QueryFilter` API across query-builder and comparison logic.
  * Updated model creation calls with safer type casting.
* **New Features**
  * Improved embedded schema type handling to support both legacy and current accessor keys via a shared helper (used in reference resolution).
* **Tests**
  * Updated fixtures and query assertions for Mongoose 9 typing changes (including `id` visibility) and adjusted helper typings/casts accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->