### PR TITLE
fix: support class-validator 0.15

### DIFF
--- a/examples/federation-v2-e2e/gateway/package.json
+++ b/examples/federation-v2-e2e/gateway/package.json
@@ -21,7 +21,7 @@
     "@nestjs/graphql": "^13.2.4",
     "@nestjs/platform-express": "^11.1.17",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
+    "class-validator": "0.15.1",
     "graphql": "^16.13.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"

--- a/examples/federation-v2-e2e/tag-service/package.json
+++ b/examples/federation-v2-e2e/tag-service/package.json
@@ -23,7 +23,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
+    "class-validator": "0.15.1",
     "graphql": "^16.13.2",
     "pg": "^8.23.0",
     "reflect-metadata": "^0.2.2",

--- a/examples/federation-v2-e2e/todo-service/package.json
+++ b/examples/federation-v2-e2e/todo-service/package.json
@@ -22,7 +22,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
+    "class-validator": "0.15.1",
     "graphql": "^16.13.2",
     "pg": "^8.23.0",
     "reflect-metadata": "^0.2.2",

--- a/examples/federation-v2-e2e/user-service/package.json
+++ b/examples/federation-v2-e2e/user-service/package.json
@@ -22,7 +22,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
+    "class-validator": "0.15.1",
     "graphql": "^16.13.2",
     "pg": "^8.23.0",
     "reflect-metadata": "^0.2.2",

--- a/packages/query-graphql/package.json
+++ b/packages/query-graphql/package.json
@@ -41,7 +41,7 @@
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "@nestjs/graphql": "^11.0.0 || ^12.0.0 || ^13.0.0",
     "class-transformer": "^0.5",
-    "class-validator": "^0.14.0",
+    "class-validator": "^0.14.0 || ^0.15.0",
     "graphql": "^16.0.0",
     "graphql-subscriptions": "^3.0.0",
     "ts-morph": "^19.0.0 || ^20.0.0 || ^21.0.0 || ^24.0.0 || ^25.0.0"

--- a/packages/query-rest/package.json
+++ b/packages/query-rest/package.json
@@ -42,6 +42,6 @@
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "@nestjs/swagger": "^10.0.0 || ^11.0.0",
     "class-transformer": "^0.5",
-    "class-validator": "^0.14.0"
+    "class-validator": "^0.14.0 || ^0.15.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,7 +4331,7 @@ __metadata:
     "@nestjs/core": ^10.0.0 || ^11.0.0
     "@nestjs/graphql": ^11.0.0 || ^12.0.0 || ^13.0.0
     class-transformer: ^0.5
-    class-validator: ^0.14.0
+    class-validator: ^0.14.0 || ^0.15.0
     graphql: ^16.0.0
     graphql-subscriptions: ^3.0.0
     ts-morph: ^19.0.0 || ^20.0.0 || ^21.0.0 || ^24.0.0 || ^25.0.0
@@ -4384,7 +4384,7 @@ __metadata:
     "@nestjs/core": ^10.0.0 || ^11.0.0
     "@nestjs/swagger": ^10.0.0 || ^11.0.0
     class-transformer: ^0.5
-    class-validator: ^0.14.0
+    class-validator: ^0.14.0 || ^0.15.0
   languageName: unknown
   linkType: soft
 
@@ -7095,17 +7095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-validator@npm:^0.14.3":
-  version: 0.14.4
-  resolution: "class-validator@npm:0.14.4"
-  dependencies:
-    "@types/validator": "npm:^13.15.3"
-    libphonenumber-js: "npm:^1.11.1"
-    validator: "npm:^13.15.22"
-  checksum: 10/a7b9c0c3bbe2f693a6eb1f6e379010fe46f1088184a94eca2247c8535c019ea7e4b11af4f7e841b051c723ebaa88ce61065e66624f4e3429a346138885969758
-  languageName: node
-  linkType: hard
-
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -9354,7 +9343,7 @@ __metadata:
     "@nestjs/schematics": "npm:^11.0.9"
     "@types/node": "npm:^24.10.1"
     class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.3"
+    class-validator: "npm:0.15.1"
     graphql: "npm:^16.13.2"
     reflect-metadata: "npm:^0.2.2"
     rxjs: "npm:^7.8.2"
@@ -15169,7 +15158,7 @@ __metadata:
     "@nestjs/typeorm": "npm:^11.0.0"
     "@types/node": "npm:^24.10.1"
     class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.3"
+    class-validator: "npm:0.15.1"
     graphql: "npm:^16.13.2"
     pg: "npm:^8.23.0"
     reflect-metadata: "npm:^0.2.2"
@@ -15445,7 +15434,7 @@ __metadata:
     "@nestjs/typeorm": "npm:^11.0.0"
     "@types/node": "npm:^24.10.1"
     class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.3"
+    class-validator: "npm:0.15.1"
     graphql: "npm:^16.13.2"
     pg: "npm:^8.23.0"
     reflect-metadata: "npm:^0.2.2"
@@ -16303,7 +16292,7 @@ __metadata:
     "@nestjs/typeorm": "npm:^11.0.0"
     "@types/node": "npm:^24.10.1"
     class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.3"
+    class-validator: "npm:0.15.1"
     graphql: "npm:^16.13.2"
     pg: "npm:^8.23.0"
     reflect-metadata: "npm:^0.2.2"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for `class-validator` 0.15 in the GraphQL and REST packages, and updates the federation examples to use 0.15.1.

- Widens the peer dependency range from `^0.14.0` to `^0.14.0 || ^0.15.0` in `packages/query-graphql` and `packages/query-rest`.
- Pins examples to `class-validator` 0.15.1 to validate compatibility.

<sup>Written for commit ce65b6bbc73d40e2b3360f31f7e320469e368c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for `class-validator` 0.15.x in GraphQL and REST query packages while retaining compatibility with 0.14.x.
* **Maintenance**
  * Updated federation example services to use the pinned `class-validator` 0.15.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->