### PR TITLE
refactor: Added `csv-stringify` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
     "clsx": "^2.1.1",
+    "csv-stringify": "^6.8.3",
     "dataloader": "2.2.3",
     "eslint": "8.57.1",
     "eslint-config-airbnb": "19.0.4",

--- a/packages/query-rest/src/decorators/controller-methods.decorator.ts
+++ b/packages/query-rest/src/decorators/controller-methods.decorator.ts
@@ -17,10 +17,12 @@ import { isArray } from 'class-validator'
 import { ReturnTypeFunc } from '../interfaces/return-type-func'
 import { isDisabled, Method, MethodOpts } from './method.decorator'
 
+export type MethodDecoratorResponse = Omit<ApiResponseOptions, 'status' | 'isArray' | 'type'> & { status: number }
+
 interface MethodDecoratorArg extends MethodOpts {
   path?: string | string[]
   operation?: ApiOperationOptions
-  response?: Omit<ApiResponseOptions, 'status' | 'isArray' | 'type'> & { status: number }
+  response?: MethodDecoratorResponse
 }
 
 interface MutationMethodDecoratorArg extends MethodDecoratorArg {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12553,6 +12553,7 @@ __metadata:
     class-transformer: "npm:0.5.1"
     class-validator: "npm:0.15.1"
     clsx: "npm:^2.1.1"
+    csv-stringify: "npm:^6.8.3"
     dataloader: "npm:2.2.3"
     eslint: "npm:8.57.1"
     eslint-config-airbnb: "npm:19.0.4"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `csv-stringify` as a dependency for the feature/rest work and exports a `MethodDecoratorResponse` type from the query-rest controller methods decorator, replacing the previously inline response type definition.

<sup>Written for commit 7bfa23e36f2371bee1cd16cbf397ad9d2e9b3375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development tooling to support CSV data formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->