### PR TITLE
fix(query-graphql): accept keyset cursors when the sort names a field twice

### DIFF
--- a/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
@@ -662,6 +662,37 @@ describe('CursorConnectionType', (): void => {
         })
       })
 
+      it('should ignore a duplicate sort field so the cursor round-trips', async () => {
+        const duplicatedSorting = [
+          { field: 'stringField' as const, direction: SortDirection.ASC },
+          { field: 'stringField' as const, direction: SortDirection.DESC }
+        ]
+        const queryMany = jest.fn()
+        const dtos = [createTestDTO(1), createTestDTO(2), createTestDTO(3)]
+        queryMany.mockResolvedValueOnce([...dtos])
+        const response = await getConnectionType().createFromPromise(queryMany, {
+          sorting: duplicatedSorting,
+          paging: createPage({ first: 2 })
+        })
+        expect(queryMany).toHaveBeenCalledWith({
+          filter: {},
+          paging: { limit: 3 },
+          sorting: [{ field: 'stringField', direction: SortDirection.ASC }]
+        })
+
+        const queryManyNextPage = jest.fn()
+        queryManyNextPage.mockResolvedValueOnce([])
+        await getConnectionType().createFromPromise(queryManyNextPage, {
+          sorting: duplicatedSorting,
+          paging: createPage({ first: 2, after: response.pageInfo.endCursor })
+        })
+        expect(queryManyNextPage).toHaveBeenCalledWith({
+          filter: { or: [{ and: [{ stringField: { gt: 'foo2' } }] }] },
+          paging: { limit: 3 },
+          sorting: [{ field: 'stringField', direction: SortDirection.ASC }]
+        })
+      })
+
       it('should create an empty connection', async () => {
         const queryMany = jest.fn()
         queryMany.mockResolvedValueOnce([])

--- a/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
+++ b/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
@@ -126,7 +126,15 @@ export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
   private getSortFields(query: Query<DTO>, opts: KeySetPagingOpts<DTO>): SortField<DTO>[] {
     const { sorting = [] } = query
     const defaultSort = opts.defaultSort.filter((dsf) => !sorting.some((sf) => dsf.field === sf.field))
-    const sortFields = [...sorting, ...defaultSort]
+    // a repeated sort field cannot change the order, and would misalign the cursor's one-entry-per-field payload
+    const seenFields = new Set<keyof DTO>()
+    const sortFields = [...sorting, ...defaultSort].filter(({ field }) => {
+      if (seenFields.has(field)) {
+        return false
+      }
+      seenFields.add(field)
+      return true
+    })
     return opts.isForward ? sortFields : invertSort(sortFields)
   }
 


### PR DESCRIPTION
A keyset cursor holds one entry per distinct field, but the sort is used exactly as sent, so a query naming the same field twice (which nothing in the schema prevents) pairs the second cursor entry against the wrong sort field and rejects the cursor it just issued. The first page succeeds and every page after it throws, an unhandled error from valid client input: `Cursor Payload does not match query sort expected <field> found <field>` in the usual case, or an undefined dereference when the duplicated field is the key set field itself (the cursor then has fewer entries than the sort).

To reproduce on any `@KeySet` DTO: sort `[{ field: 'name', direction: ASC }, { field: 'name', direction: DESC }]` with `first: 2`, then request the next page with the returned `endCursor`. Reproduced on 9.4.0 and the code is unchanged on current master. There's no existing issue for this, so I've included the bug report details here per the contributing guidelines.

The fix drops repeated sort fields before the boundary and the cursor are built. A repeat can't change the order (rows tied on the first occurrence are tied on every later one), so only the first occurrence matters.

Test added in `cursor-connection.type.spec.ts` paging a duplicated sort through two pages and asserting the second page builds the right boundary from the first page's cursor. `nx test query-graphql` and `nx lint query-graphql` pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyset cursor pagination breaking when a query sorts by the same field more than once. Previously, the first page succeeded but every subsequent page threw a `Cursor Payload does not match query sort` error or an undefined dereference, because the cursor payload's one-entry-per-field structure misaligned with the duplicated sort. Now repeated sort fields are dropped before building the boundary and cursor, so pagination round-trips correctly. Repeats cannot change the order, so only the first occurrence matters.

- Adds a test that pages through two pages with a duplicated sort field and verifies the second page builds the correct boundary from the first page's cursor.

<sup>Written for commit 8e271abae217903d37b396676650fb5784d81284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cursor-based pagination when the same sort field is specified more than once.
  - Duplicate sort fields are now handled consistently, preserving the intended sort order and ensuring next-page cursors generate the correct filters.

- **Tests**
  - Added coverage to verify sorting, cursor generation, and subsequent-page requests when duplicate sort fields are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->