### PR TITLE
fix(query-graphql): keep keyset date boundaries correct across timezones

### DIFF
--- a/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
@@ -824,6 +824,98 @@ describe('CursorConnectionType', (): void => {
       })
     })
 
+    it('should revive a legacy cursor on a backward page into an inverted date boundary', async () => {
+      const instant = new Date(Date.UTC(2026, 0, 3, 11, 30, 0, 0))
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([])
+      await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({
+          last: 2,
+          before: keysetCursor([
+            { field: 'dueDate', value: '2026-01-03T11:30:00.000Z' },
+            { field: 'id', value: 2 }
+          ])
+        })
+      })
+      expect(queryMany).toHaveBeenCalledWith({
+        filter: {
+          or: [{ and: [{ dueDate: { lt: instant } }] }, { and: [{ dueDate: { eq: instant } }, { id: { lt: 2 } }] }]
+        },
+        paging: { limit: 3 },
+        sorting: [
+          { field: 'dueDate', direction: SortDirection.DESC },
+          { field: 'id', direction: SortDirection.DESC }
+        ]
+      })
+    })
+
+    it('should pass a wall clock boundary through verbatim on a backward page', async () => {
+      const mintedWallClock = '2026-01-04 22:30:00.000+11:00'
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([])
+      await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({
+          last: 2,
+          before: keysetCursor([
+            { field: 'dueDate', value: mintedWallClock },
+            { field: 'id', value: 2 }
+          ])
+        })
+      })
+      expect(queryMany).toHaveBeenCalledWith({
+        filter: {
+          or: [
+            { and: [{ dueDate: { lt: mintedWallClock } }] },
+            { and: [{ dueDate: { eq: mintedWallClock } }, { id: { lt: 2 } }] }
+          ]
+        },
+        paging: { limit: 3 },
+        sorting: [
+          { field: 'dueDate', direction: SortDirection.DESC },
+          { field: 'id', direction: SortDirection.DESC }
+        ]
+      })
+    })
+
+    it('should pass a minted wall clock through verbatim on a key set date field with no filterable metadata', async () => {
+      @ObjectType('TestPlainDateKeySet')
+      @KeySet(['createdAt'])
+      class TestPlainDateKeySetDTO {
+        @Field()
+        createdAt!: Date
+      }
+      const ConnectionType = getOrCreateCursorConnectionType(TestPlainDateKeySetDTO, {
+        pagingStrategy: PagingStrategies.CURSOR
+      })
+
+      const dtos = [
+        { createdAt: new Date(Date.UTC(2026, 0, 3, 11, 30)) },
+        { createdAt: new Date(Date.UTC(2026, 0, 4, 11, 30)) },
+        { createdAt: new Date(Date.UTC(2026, 0, 5, 11, 30)) }
+      ]
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([...dtos])
+      const response = await ConnectionType.createFromPromise(queryMany, { paging: createPage({ first: 2 }) })
+      const decoded = JSON.parse(Buffer.from(response.pageInfo.endCursor, 'base64').toString()) as {
+        fields: { field: string; value: string }[]
+      }
+      const mintedWallClock = decoded.fields.find(({ field }) => field === 'createdAt').value
+      expect(mintedWallClock).toMatch(WALL_CLOCK_FORMAT)
+
+      const queryManyNextPage = jest.fn()
+      queryManyNextPage.mockResolvedValueOnce([])
+      await ConnectionType.createFromPromise(queryManyNextPage, {
+        paging: createPage({ first: 2, after: response.pageInfo.endCursor })
+      })
+      expect(queryManyNextPage).toHaveBeenCalledWith({
+        filter: { or: [{ and: [{ createdAt: { gt: mintedWallClock } }] }] },
+        paging: { limit: 3 },
+        sorting: [{ field: 'createdAt', direction: SortDirection.ASC }]
+      })
+    })
+
     it('should never revive a date looking value on a field that is not a date', async () => {
       const queryMany = jest.fn()
       queryMany.mockResolvedValueOnce([])

--- a/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
@@ -4,7 +4,7 @@ import { SortDirection } from '@ptc-org/nestjs-query-core'
 import { CursorConnectionType, CursorPagingType, PagingStrategies, StaticConnectionType } from '@ptc-org/nestjs-query-graphql'
 import { plainToClass } from 'class-transformer'
 
-import { KeySet } from '../../../src/decorators'
+import { FilterableField, KeySet } from '../../../src/decorators'
 import { getOrCreateCursorConnectionType } from '../../../src/types/connection'
 import { getOrCreateCursorPagingType } from '../../../src/types/query/paging'
 import { generateSchema } from '../../__fixtures__'
@@ -713,6 +713,142 @@ describe('CursorConnectionType', (): void => {
           },
           totalCountFn: expect.any(Function)
         })
+      })
+    })
+  })
+  describe('keyset connection with date sort fields', () => {
+    @ObjectType('TestDated')
+    @KeySet(['id'])
+    class TestDatedDTO {
+      @FilterableField()
+      id!: number
+
+      @FilterableField()
+      dueDate!: Date
+
+      @FilterableField()
+      label!: string
+    }
+
+    function getDatedConnectionType(): StaticConnectionType<TestDatedDTO, PagingStrategies.CURSOR> {
+      return getOrCreateCursorConnectionType(TestDatedDTO, { pagingStrategy: PagingStrategies.CURSOR })
+    }
+
+    const keysetCursor = (fields: { field: string; value: unknown }[]): string =>
+      Buffer.from(JSON.stringify({ type: 'keyset', fields })).toString('base64')
+
+    const WALL_CLOCK_FORMAT = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/
+
+    it('should revive a legacy UTC ISO cursor value into a date for the filter', async () => {
+      const instant = new Date(Date.UTC(2026, 0, 3, 11, 30, 0, 0))
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([])
+      await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({
+          first: 2,
+          after: keysetCursor([
+            { field: 'dueDate', value: '2026-01-03T11:30:00.000Z' },
+            { field: 'id', value: 2 }
+          ])
+        })
+      })
+      expect(queryMany).toHaveBeenCalledWith({
+        filter: {
+          or: [{ and: [{ dueDate: { gt: instant } }] }, { and: [{ dueDate: { eq: instant } }, { id: { gt: 2 } }] }]
+        },
+        paging: { limit: 3 },
+        sorting: [
+          { field: 'dueDate', direction: SortDirection.ASC },
+          { field: 'id', direction: SortDirection.ASC }
+        ]
+      })
+    })
+
+    it('should mint date boundaries as a wall clock with the offset embedded', async () => {
+      const dtos = [
+        { id: 1, dueDate: new Date(Date.UTC(2026, 0, 3, 11, 30)), label: 'a' },
+        { id: 2, dueDate: new Date(Date.UTC(2026, 0, 4, 11, 30)), label: 'b' },
+        { id: 3, dueDate: new Date(Date.UTC(2026, 0, 5, 11, 30)), label: 'c' }
+      ]
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([...dtos])
+      const response = await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({ first: 2 })
+      })
+
+      const decoded = JSON.parse(Buffer.from(response.pageInfo.endCursor, 'base64').toString()) as {
+        fields: { field: string; value: string }[]
+      }
+      const dueDateValue = decoded.fields.find(({ field }) => field === 'dueDate').value
+      expect(dueDateValue).toMatch(WALL_CLOCK_FORMAT)
+      expect(new Date(dueDateValue.replace(' ', 'T')).getTime()).toBe(dtos[1].dueDate.getTime())
+    })
+
+    it('should pass a wall clock boundary through to the filter verbatim', async () => {
+      const dtos = [
+        { id: 1, dueDate: new Date(Date.UTC(2026, 0, 3, 11, 30)), label: 'a' },
+        { id: 2, dueDate: new Date(Date.UTC(2026, 0, 4, 11, 30)), label: 'b' },
+        { id: 3, dueDate: new Date(Date.UTC(2026, 0, 5, 11, 30)), label: 'c' }
+      ]
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([...dtos])
+      const response = await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({ first: 2 })
+      })
+      const decoded = JSON.parse(Buffer.from(response.pageInfo.endCursor, 'base64').toString()) as {
+        fields: { field: string; value: string }[]
+      }
+      const mintedWallClock = decoded.fields.find(({ field }) => field === 'dueDate').value
+
+      const queryManyNextPage = jest.fn()
+      queryManyNextPage.mockResolvedValueOnce([])
+      await getDatedConnectionType().createFromPromise(queryManyNextPage, {
+        sorting: [{ field: 'dueDate', direction: SortDirection.ASC }],
+        paging: createPage({ first: 2, after: response.pageInfo.endCursor })
+      })
+      expect(queryManyNextPage).toHaveBeenCalledWith({
+        filter: {
+          or: [
+            { and: [{ dueDate: { gt: mintedWallClock } }] },
+            { and: [{ dueDate: { eq: mintedWallClock } }, { id: { gt: 2 } }] }
+          ]
+        },
+        paging: { limit: 3 },
+        sorting: [
+          { field: 'dueDate', direction: SortDirection.ASC },
+          { field: 'id', direction: SortDirection.ASC }
+        ]
+      })
+    })
+
+    it('should never revive a date looking value on a field that is not a date', async () => {
+      const queryMany = jest.fn()
+      queryMany.mockResolvedValueOnce([])
+      await getDatedConnectionType().createFromPromise(queryMany, {
+        sorting: [{ field: 'label', direction: SortDirection.ASC }],
+        paging: createPage({
+          first: 2,
+          after: keysetCursor([
+            { field: 'label', value: '2026-01-03T11:30:00.000Z' },
+            { field: 'id', value: 2 }
+          ])
+        })
+      })
+      expect(queryMany).toHaveBeenCalledWith({
+        filter: {
+          or: [
+            { and: [{ label: { gt: '2026-01-03T11:30:00.000Z' } }] },
+            { and: [{ label: { eq: '2026-01-03T11:30:00.000Z' } }, { id: { gt: 2 } }] }
+          ]
+        },
+        paging: { limit: 3 },
+        sorting: [
+          { field: 'label', direction: SortDirection.ASC },
+          { field: 'id', direction: SortDirection.ASC }
+        ]
       })
     })
   })

--- a/packages/query-graphql/__tests__/types/connection/cursor/pager/strategies/helpers.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor/pager/strategies/helpers.spec.ts
@@ -1,0 +1,77 @@
+import {
+  reviveLegacyCursorDate,
+  serializeCursorDate
+} from '../../../../../../src/types/connection/cursor/pager/strategies/helpers'
+
+describe('keyset cursor date helpers', () => {
+  describe('serializeCursorDate', () => {
+    it('serializes a date so the embedded offset reconstructs the exact instant', () => {
+      const date = new Date(Date.UTC(2026, 0, 3, 11, 30, 15, 250))
+      const serialized = serializeCursorDate(date) as string
+      const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})([+-])(\d{2}):(\d{2})$/.exec(serialized)
+      expect(match).not.toBeNull()
+      const [, year, month, day, hour, minute, second, millisecond, offsetSign, offsetHours, offsetMinutes] = match
+      const totalOffsetMinutes = (offsetSign === '-' ? -1 : 1) * (Number(offsetHours) * 60 + Number(offsetMinutes))
+      const instantFromWallClock =
+        Date.UTC(+year, +month - 1, +day, +hour, +minute, +second, +millisecond) - totalOffsetMinutes * 60_000
+      expect(instantFromWallClock).toBe(date.getTime())
+    })
+
+    it('returns an invalid date untouched', () => {
+      const invalid = new Date(NaN)
+      expect(serializeCursorDate(invalid)).toBe(invalid)
+    })
+
+    describe('across minting offsets', () => {
+      const instant = new Date(Date.UTC(2026, 0, 3, 0, 30, 0, 0))
+
+      afterEach(() => {
+        jest.restoreAllMocks()
+      })
+
+      const mintAtOffset = (offsetMinutes: number, date: Date = instant): Date | string => {
+        jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(offsetMinutes)
+        return serializeCursorDate(date)
+      }
+
+      it('embeds the minting wall clock and offset, not UTC', () => {
+        expect(mintAtOffset(-660)).toBe('2026-01-03 11:30:00.000+11:00')
+        expect(mintAtOffset(300)).toBe('2026-01-02 19:30:00.000-05:00')
+        expect(mintAtOffset(0)).toBe('2026-01-03 00:30:00.000+00:00')
+      })
+
+      it('handles half hour offsets', () => {
+        expect(mintAtOffset(-330)).toBe('2026-01-03 06:00:00.000+05:30')
+      })
+
+      it('reconstructs the same instant from every minting offset', () => {
+        const date = new Date(Date.UTC(2026, 5, 15, 22, 45, 30, 123))
+        for (const offsetMinutes of [-660, 300, -330, 0]) {
+          const serialized = mintAtOffset(offsetMinutes, date) as string
+          expect(new Date(serialized.replace(' ', 'T')).getTime()).toBe(date.getTime())
+        }
+      })
+    })
+  })
+
+  describe('reviveLegacyCursorDate', () => {
+    it('revives a legacy UTC ISO value to the exact instant', () => {
+      const revived = reviveLegacyCursorDate('2026-01-03T11:30:00.000Z')
+      expect(revived).toBeInstanceOf(Date)
+      expect((revived as Date).getTime()).toBe(Date.UTC(2026, 0, 3, 11, 30, 0, 0))
+    })
+
+    it('leaves a wall clock value untouched', () => {
+      expect(reviveLegacyCursorDate('2026-01-03 11:30:00.000+11:00')).toBe('2026-01-03 11:30:00.000+11:00')
+    })
+
+    it('leaves a legacy shaped string that is not a real date untouched', () => {
+      expect(reviveLegacyCursorDate('2026-99-99T99:99:99.000Z')).toBe('2026-99-99T99:99:99.000Z')
+    })
+
+    it('leaves values that are not legacy date strings untouched', () => {
+      expect(reviveLegacyCursorDate('foo')).toBe('foo')
+      expect(reviveLegacyCursorDate('2026-01-03')).toBe('2026-01-03')
+    })
+  })
+})

--- a/packages/query-graphql/__tests__/types/connection/cursor/pager/strategies/helpers.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor/pager/strategies/helpers.spec.ts
@@ -69,6 +69,12 @@ describe('keyset cursor date helpers', () => {
       expect(reviveLegacyCursorDate('2026-99-99T99:99:99.000Z')).toBe('2026-99-99T99:99:99.000Z')
     })
 
+    it('leaves a calendar invalid string untouched rather than letting the parser roll it over', () => {
+      expect(reviveLegacyCursorDate('2026-02-30T10:20:30.000Z')).toBe('2026-02-30T10:20:30.000Z')
+      expect(reviveLegacyCursorDate('2025-02-29T10:20:30.000Z')).toBe('2025-02-29T10:20:30.000Z')
+      expect(reviveLegacyCursorDate('2026-01-15T24:00:00.000Z')).toBe('2026-01-15T24:00:00.000Z')
+    })
+
     it('leaves values that are not legacy date strings untouched', () => {
       expect(reviveLegacyCursorDate('foo')).toBe('foo')
       expect(reviveLegacyCursorDate('2026-01-03')).toBe('2026-01-03')

--- a/packages/query-graphql/src/types/connection/cursor/pager/strategies/helpers.ts
+++ b/packages/query-graphql/src/types/connection/cursor/pager/strategies/helpers.ts
@@ -20,7 +20,7 @@ export function decodeBase64(str: string): string {
   return Buffer.from(str, 'base64').toString('utf8')
 }
 
-const LEGACY_UTC_CURSOR_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/
+const LEGACY_UTC_CURSOR_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
 const pad = (num: number): string => String(num).padStart(2, '0')
 
@@ -49,5 +49,6 @@ export function reviveLegacyCursorDate(value: string): Date | string {
     return value
   }
   const revived = new Date(value)
-  return Number.isNaN(revived.getTime()) ? value : revived
+  // only strings toISOString could have minted revive; parser rollovers like 2026-02-30 pass through
+  return !Number.isNaN(revived.getTime()) && revived.toISOString() === value ? revived : value
 }

--- a/packages/query-graphql/src/types/connection/cursor/pager/strategies/helpers.ts
+++ b/packages/query-graphql/src/types/connection/cursor/pager/strategies/helpers.ts
@@ -19,3 +19,35 @@ export function encodeBase64(str: string): string {
 export function decodeBase64(str: string): string {
   return Buffer.from(str, 'base64').toString('utf8')
 }
+
+const LEGACY_UTC_CURSOR_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/
+
+const pad = (num: number): string => String(num).padStart(2, '0')
+
+/**
+ * Serializes a cursor boundary `Date` as the minting process's wall clock with its UTC offset
+ * embedded (e.g. `2026-01-03 11:30:00.000+11:00`), so the boundary stays correct for `timestamp`
+ * columns regardless of the minting and consuming processes' timezones.
+ */
+export function serializeCursorDate(value: Date): Date | string {
+  if (Number.isNaN(value.getTime())) {
+    return value
+  }
+  // getTimezoneOffset is instant-specific (DST safe) and counts minutes behind UTC, so its sign is inverted
+  const offsetMinutes = value.getTimezoneOffset()
+  const wallClock = new Date(value.getTime() - offsetMinutes * 60_000).toISOString().slice(0, -1).replace('T', ' ')
+  const absOffsetMinutes = Math.abs(offsetMinutes)
+  return `${wallClock}${offsetMinutes > 0 ? '-' : '+'}${pad(Math.floor(absOffsetMinutes / 60))}:${pad(absOffsetMinutes % 60)}`
+}
+
+/**
+ * Revives a `Date` boundary from a cursor minted by older versions, which serialized dates as
+ * UTC ISO strings. Anything that is not exactly the legacy format is returned untouched.
+ */
+export function reviveLegacyCursorDate(value: string): Date | string {
+  if (!LEGACY_UTC_CURSOR_DATE.test(value)) {
+    return value
+  }
+  const revived = new Date(value)
+  return Number.isNaN(revived.getTime()) ? value : revived
+}

--- a/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
+++ b/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
@@ -2,11 +2,22 @@ import { BadRequestException } from '@nestjs/common'
 import { Class, Filter, invertSort, mergeFilter, Query, SortDirection, SortField } from '@ptc-org/nestjs-query-core'
 import { plainToClass } from 'class-transformer'
 
+import { getFilterableFields } from '../../../../../decorators/filterable-field.decorator'
 import { CursorPagingType } from '../../../../query'
-import { decodeBase64, encodeBase64, hasBeforeCursor, isBackwardPaging, isForwardPaging } from './helpers'
+import {
+  decodeBase64,
+  encodeBase64,
+  hasBeforeCursor,
+  isBackwardPaging,
+  isForwardPaging,
+  reviveLegacyCursorDate,
+  serializeCursorDate
+} from './helpers'
 import { KeySetCursorPayload, KeySetPagingOpts, PagerStrategy } from './pager-strategy'
 
 export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
+  private dateFields?: Set<string>
+
   constructor(
     readonly DTOClass: Class<DTO>,
     readonly pageFields: (keyof DTO)[],
@@ -85,7 +96,10 @@ export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
         {}
       )
       const transformed = plainToClass(this.DTOClass, partial)
-      const typesafeFields = payload.fields.map(({ field }) => ({ field, value: transformed[field] }))
+      const typesafeFields = payload.fields.map(({ field, value }) => ({
+        field,
+        value: this.fromCursorValue(field, value, transformed[field])
+      }))
       return { ...payload, fields: typesafeFields }
     } catch (e) {
       throw new BadRequestException('Invalid cursor')
@@ -138,6 +152,30 @@ export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
     return opts.isForward ? sortFields : invertSort(sortFields)
   }
 
+  // a Date boundary travels as the minting process's wall clock with its UTC offset embedded
+  private toCursorValue(value: DTO[keyof DTO]): DTO[keyof DTO] {
+    return value instanceof Date ? (serializeCursorDate(value) as unknown as DTO[keyof DTO]) : value
+  }
+
+  // legacy UTC ISO strings are revived to Dates; wall clock values pass through untouched
+  private fromCursorValue(field: keyof DTO, rawValue: unknown, transformedValue: DTO[keyof DTO]): DTO[keyof DTO] {
+    if (typeof rawValue === 'string' && this.isDateField(field)) {
+      return reviveLegacyCursorDate(rawValue) as unknown as DTO[keyof DTO]
+    }
+    return transformedValue
+  }
+
+  private isDateField(field: keyof DTO): boolean {
+    if (!this.dateFields) {
+      this.dateFields = new Set(
+        getFilterableFields(this.DTOClass)
+          .filter(({ target }) => target === Date)
+          .map(({ propertyName }) => propertyName)
+      )
+    }
+    return this.dateFields.has(field as string)
+  }
+
   private createKeySetPayload(dto: DTO, fields: (keyof DTO)[]): KeySetCursorPayload<DTO> {
     const fieldSet = new Set<keyof DTO>()
     return fields.reduce(
@@ -146,7 +184,7 @@ export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
           return payload
         }
         fieldSet.add(field)
-        payload.fields.push({ field, value: dto[field] })
+        payload.fields.push({ field, value: this.toCursorValue(dto[field]) })
         return payload
       },
       { type: 'keyset', fields: [] }


### PR DESCRIPTION
## Problem

Keyset cursors serialise `Date` boundaries through `JSON.stringify`, which renders them as UTC ISO strings, and the decode side passes those strings straight into the filter. A `timestamp` (without time zone) column casts the parameter by dropping the zone, so on any server not running UTC the boundary shifts by the process's UTC offset and paging stops advancing (the page re-serves rows it already returned, or reports itself complete early). Anyone running UTC never sees this, which I suspect is why it's survived so long.

To reproduce: on a process with `TZ` set to anything non-UTC (e.g. `Australia/Sydney`), page a `@KeySet` DTO sorted by a `timestamp` column with values closer together than the process's UTC offset (e.g. hourly timestamps under an 11 hour offset), `first: 2`, and follow `endCursor`. Pages repeat or skip rows depending on sort direction.

## Fix

Two halves, and they compose:

**Minting.** A `Date` boundary is now serialised as the minting process's wall clock with its UTC offset embedded, e.g. `2026-01-03 11:30:00.000+11:00`. The wall clock travels verbatim into a `timestamp` comparison (the cast drops the offset), and the embedded offset keeps instant-typed stores exact (`timestamptz`, BSON dates via mongoose's cast, sequelize `DATE`). This is the important property: the boundary stays correct even when the minting and consuming servers run in **different** timezones, because the value the database compares no longer depends on either process's local clock.

**Decoding old cursors.** Cursors minted by older versions still carry UTC ISO strings, and those are now revived to `Date` objects before they reach the filter, so the driver renders them in the consuming process's timezone. On UTC servers that's byte-identical to what happened before, so there is no regression, and on non-UTC servers where minting and consuming share a timezone it actually fixes the old cursors too. What old cursors can't get, even in principle, is cross-timezone correctness (a UTC ISO string carries the instant but not the minting zone), so that guarantee applies once a cursor is reminted, which happens naturally on the next page fetch. There's an explicit compatibility test for the old format.

Revival is driven by DTO metadata (`@FilterableField` design type is `Date`), never by sniffing string content, so an ISO-looking value on a string field is left alone. Wall clock values pass through as strings untouched, which is deliberate: reviving them to an instant would re-introduce the consumer's local clock and undo the cross-timezone property for `timestamp` columns.

## Tests

- `helpers.spec.ts` (new): serialisation at explicit minting offsets by spying on `Date.prototype.getTimezoneOffset` (+11:00 Sydney DST, -05:00 New York, the +05:30 half-hour case, and +00:00, so the sign inversion is pinned in both directions), an instant-reconstruction round trip from every offset, the invalid-date guard, and legacy revival (exact instant back, wall clock and non-date strings untouched, and a legacy shaped string that isn't a real date left alone rather than revived to an invalid date). The spy is what makes the offset arithmetic unit-testable at all, since a test that happens to run under UTC proves nothing about it.
- `cursor-connection.type.spec.ts`: an old-format UTC ISO cursor decodes to the exact instant in the filter (the compatibility guarantee), a minted cursor carries the wall clock format and reconstructs the right instant, a wall clock boundary passes through to the filter verbatim on the next page, and a date-looking value on a non-date field is never revived.
- The full `query-graphql` suite passes under `TZ=UTC`, `TZ=America/New_York` and `TZ=Australia/Sydney`, plus lint and build.

## Behaviour change

The cursor wire format for date boundaries changes from `2026-01-03T11:30:00.000Z` to `2026-01-03 11:30:00.000+11:00`. Old cursors keep working (see above), new cursors are understood only by the new code, so this rolls forward cleanly but a rollback would strand cursors minted in between (they'd hit the field as unrevived strings, which is the pre-fix behaviour, not an error).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyset cursor date boundaries so paging no longer repeats or skips rows when a process runs in a non-UTC timezone. Date boundaries are now minted as the process's wall clock with its UTC offset embedded (e.g. `2026-01-03 11:30:00.000+11:00`) instead of a UTC ISO string, so `timestamp` columns compare the wall clock verbatim while instant-typed stores stay exact — including when minting and consuming servers run in different timezones.

**Migration**
- Old cursors still decode: legacy UTC ISO strings are revived to `Date` objects, driven by DTO metadata declaring `Date` fields, with a `toISOString` round trip gating revival so calendar-invalid strings pass through untouched.
- Legacy cursors gain same-timezone correctness only; full cross-timezone correctness applies once a cursor is reminted on the next page fetch.
- New cursors require the new code, so a rollback strands cursors minted in between (decoded as pre-fix strings, not an error).

<sup>Written for commit 394226c4d09756e354b06fd064b8abd72c8d29be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cursor-based pagination for date fields across time zones.
  - Date cursors now preserve the correct local wall-clock time and UTC offset, including half-hour offsets.
  - Existing cursors using the previous date format continue to work correctly.
  - Date-like values on non-date fields remain unchanged, preventing unintended conversions.
  - Prevented duplicate sort fields from causing cursor values to become misaligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->