### PR TITLE
feat(typeorm,graphql): add `on` to relation filters for JOIN ON conditions

### DIFF
--- a/docs/concepts/queries.mdx
+++ b/docs/concepts/queries.mdx
@@ -116,6 +116,44 @@ const q: Query<MyClass> = {
 }
 ```
 
+### Relation Join Conditions[​](#relation-join-conditions 'Direct link to Relation Join Conditions')
+
+A relation filter also accepts an `on` key. Its conditions are added to that relation's SQL `JOIN ... ON` clause instead of the `WHERE` clause, which preserves `LEFT JOIN` semantics: parent records without a matching child are still returned.
+
+<Warning>This functionality only works for typeorm!</Warning>
+
+In this example every `myClass` is returned, and only its uncompleted `subTasks` take part in the join: `LEFT JOIN sub_task ON sub_task.my_class_id = my_class.id AND sub_task.completed = FALSE`.
+
+```ts
+const q: Query<MyClass> = {
+  filter: {
+    subTasks: {
+      on: { completed: { is: false } }
+    }
+  }
+}
+```
+
+Move the same condition out of `on` and it becomes a `WHERE` condition instead, which drops every `myClass` that has no uncompleted `subTask`. The two can be combined, so you can restrict what the join matches and still filter the parents:
+
+```ts
+const q: Query<MyClass> = {
+  filter: {
+    subTasks: {
+      on: { completed: { is: false } },
+      title: { like: '%urgent%' }
+    }
+  }
+}
+```
+
+Join conditions may be grouped with `and` and `or`, but they cannot reference further relations, because a join condition can only refer to the relation being joined.
+
+<Warning>
+  `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`
+  expression, has no join to attach to and is rejected with an error.
+</Warning>
+
 ---
 
 ## Paging[​](#paging 'Direct link to Paging')

--- a/docs/concepts/queries.mdx
+++ b/docs/concepts/queries.mdx
@@ -120,7 +120,12 @@ const q: Query<MyClass> = {
 
 A relation filter also accepts an `on` key. Its conditions are added to that relation's SQL `JOIN ... ON` clause instead of the `WHERE` clause, which preserves `LEFT JOIN` semantics: parent records without a matching child are still returned.
 
-<Warning>This functionality only works for typeorm!</Warning>
+The key is opt-in and off by default. In a GraphQL application it is enabled with `@QueryOptions({ enableRelationJoinConditions: true })` on the DTO that appears as the relation, which can also be set once on a shared base DTO, and `@QueryOptions({ enableRelationJoinConditions: { field: 'joinOn' } })` picks a different key for a DTO that already has a field called `on`. See [filtering](../graphql/queries/filtering#filtering-a-relation-join-with-on) for the details.
+
+<Warning>
+  This functionality only works for typeorm! The `sequelize`, `mongoose`, `typegoose` and `mikro-orm` adapters throw
+  from `forFeature` at application startup when they are asked to serve a DTO that enables it.
+</Warning>
 
 In this example every `myClass` is returned, and only its uncompleted `subTasks` take part in the join: `LEFT JOIN sub_task ON sub_task.my_class_id = my_class.id AND sub_task.completed = FALSE`.
 
@@ -149,7 +154,7 @@ const q: Query<MyClass> = {
 
 Join conditions may be grouped with `and` and `or`, but they cannot reference further relations, because a join condition can only refer to the relation being joined.
 
-Because the conditions are applied to a `LEFT JOIN`, a to-many relation yields one row per matching child, so an unpaged query can return the same parent more than once. Paged queries are not affected, because paging uses a distinct-id subquery. This is ordinary SQL join behaviour rather than anything specific to `on`, but `on` makes it easy to run into, since keeping every parent is the whole point.
+Joining a to-many relation produces one row per matching child, but queries, counts and paging all account for that already, so records are not returned twice. Aggregates are the exception: they read raw rows, so an aggregate over a to-many relation counts each parent once per matching child. That applies to any relation filter rather than to `on` specifically, but `on` makes it easier to reach, since keeping every parent is the whole point.
 
 <Warning>
   `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`

--- a/docs/concepts/queries.mdx
+++ b/docs/concepts/queries.mdx
@@ -149,6 +149,8 @@ const q: Query<MyClass> = {
 
 Join conditions may be grouped with `and` and `or`, but they cannot reference further relations, because a join condition can only refer to the relation being joined.
 
+Because the conditions are applied to a `LEFT JOIN`, a to-many relation yields one row per matching child, so an unpaged query can return the same parent more than once. Paged queries are not affected, because paging uses a distinct-id subquery. This is ordinary SQL join behaviour rather than anything specific to `on`, but `on` makes it easy to run into, since keeping every parent is the whole point.
+
 <Warning>
   `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`
   expression, has no join to attach to and is rejected with an error.

--- a/docs/graphql/queries/filtering.mdx
+++ b/docs/graphql/queries/filtering.mdx
@@ -77,6 +77,49 @@ The following example filters for all todoItems that are marked completed.
 </Tab>
 </Tabs>
 
+## Filtering a relation join with `on`
+
+Filtering on a relation normally constrains the parent records: a `todoItem` is only returned when one of its `subTasks` matches. When you instead want to narrow which related records the join considers, while still returning every parent, put the conditions under `on`.
+
+Conditions under `on` are added to that relation's SQL `JOIN ... ON` clause rather than the `WHERE` clause, so the `LEFT JOIN` keeps parents that have no matching child.
+
+<Warning>This functionality only works for typeorm!</Warning>
+
+```graphql
+{
+  todoItems(filter: { subTasks: { on: { completed: { is: false } } } }) {
+    edges {
+      node {
+        id
+        title
+      }
+    }
+  }
+}
+```
+
+Both forms can be used on the same relation. Here the join only matches uncompleted `subTasks`, and the `WHERE` clause then keeps only the `todoItems` that have such a subtask with a matching title:
+
+```graphql
+{
+  todoItems(filter: { subTasks: { on: { completed: { is: false } }, title: { like: "%urgent%" } } }) {
+    edges {
+      node {
+        id
+        title
+      }
+    }
+  }
+}
+```
+
+The generated `on` input accepts the relation's own fields plus `and` and `or`. It deliberately has no relation fields, since a join condition can only reference the relation being joined.
+
+<Warning>
+  `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`
+  expression, has no join to attach to and is rejected with an error.
+</Warning>
+
 ## Setting the generated filter-type depth
 
 When querying the default filter is one level deep. You can specify the generated filter-type depth by using the `QueryOptions` decorator on your DTO.

--- a/docs/graphql/queries/filtering.mdx
+++ b/docs/graphql/queries/filtering.mdx
@@ -115,6 +115,8 @@ Both forms can be used on the same relation. Here the join only matches uncomple
 
 The generated `on` input accepts the relation's own fields plus `and` and `or`. It deliberately has no relation fields, since a join condition can only reference the relation being joined.
 
+Because the conditions are applied to a `LEFT JOIN`, a to-many relation yields one row per matching child, so an unpaged query can return the same parent more than once. Paged queries are not affected, because paging uses a distinct-id subquery. This is ordinary SQL join behaviour rather than anything specific to `on`, but `on` makes it easy to run into, since keeping every parent is the whole point.
+
 <Warning>
   `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`
   expression, has no join to attach to and is rejected with an error.

--- a/docs/graphql/queries/filtering.mdx
+++ b/docs/graphql/queries/filtering.mdx
@@ -83,7 +83,44 @@ Filtering on a relation normally constrains the parent records: a `todoItem` is 
 
 Conditions under `on` are added to that relation's SQL `JOIN ... ON` clause rather than the `WHERE` clause, so the `LEFT JOIN` keeps parents that have no matching child.
 
-<Warning>This functionality only works for typeorm!</Warning>
+The feature is opt-in and off by default. Enable it on the DTO that appears as the relation, and the `on` field is added wherever that DTO is used as a filterable relation:
+
+```ts
+@ObjectType('SubTask')
+@QueryOptions({ enableRelationJoinConditions: true })
+export class SubTaskDTO {
+  @FilterableField()
+  completed!: boolean
+}
+```
+
+With the option off, neither the `on` field nor the `SubTaskOnConditionFilter` input type is generated at all.
+
+`enableRelationJoinConditions` also accepts an object, which lets you choose the key. Use it when the DTO already has a field called `on`, since the key is the runtime property name as well as the GraphQL field name:
+
+```ts
+@ObjectType('SubTask')
+@QueryOptions({ enableRelationJoinConditions: { field: 'joinOn' } })
+export class SubTaskDTO {
+  @FilterableField()
+  on!: string
+}
+```
+
+Enabling the option on a DTO whose own filterable field or relation is named the same as the configured key throws at schema generation time, naming the DTO and the clashing member.
+
+The option is inherited, so a shared base DTO can turn it on once for every DTO that extends it:
+
+```ts
+@ObjectType({ isAbstract: true })
+@QueryOptions({ enableRelationJoinConditions: true })
+export abstract class JoinableDTO {}
+```
+
+<Warning>
+  This functionality only works for typeorm! The `sequelize`, `mongoose`, `typegoose` and `mikro-orm` adapters throw
+  from `forFeature` at application startup when they are asked to serve a DTO that enables it.
+</Warning>
 
 ```graphql
 {
@@ -115,7 +152,7 @@ Both forms can be used on the same relation. Here the join only matches uncomple
 
 The generated `on` input accepts the relation's own fields plus `and` and `or`. It deliberately has no relation fields, since a join condition can only reference the relation being joined.
 
-Because the conditions are applied to a `LEFT JOIN`, a to-many relation yields one row per matching child, so an unpaged query can return the same parent more than once. Paged queries are not affected, because paging uses a distinct-id subquery. This is ordinary SQL join behaviour rather than anything specific to `on`, but `on` makes it easy to run into, since keeping every parent is the whole point.
+Joining a to-many relation produces one row per matching child, but queries, counts and paging all account for that already, so records are not returned twice. Aggregates are the exception: they read raw rows, so an aggregate over a to-many relation counts each parent once per matching child. That applies to any relation filter rather than to `on` specifically, but `on` makes it easier to reach, since keeping every parent is the whole point.
 
 <Warning>
   `on` is only honoured at the top level of a relation filter. An `on` at the root filter level, or inside an `and`/`or`

--- a/packages/core/__tests__/helpers.spec.ts
+++ b/packages/core/__tests__/helpers.spec.ts
@@ -192,6 +192,15 @@ describe('applyFilter', () => {
     expect(applyFilter({ first: 'bar', last: 'foo' }, filter)).toBe(false)
   })
 
+  it('should ignore join conditions, which have no in memory equivalent', () => {
+    const filter: Filter<TestDTO> = {
+      on: { first: { eq: 'never-matches' } },
+      last: { eq: 'bar' }
+    }
+    expect(applyFilter({ first: 'foo', last: 'bar' }, filter)).toBe(true)
+    expect(applyFilter({ first: 'foo', last: 'foo' }, filter)).toBe(false)
+  })
+
   it('should handle neq comparisons', () => {
     const filter: Filter<TestDTO> = {
       first: { neq: 'foo' }
@@ -672,6 +681,17 @@ describe('getFilterFields', () => {
       }
     }
     expect(getFilterFields(filter).sort()).toEqual(['boolField', 'strField', 'testRelation'])
+  })
+
+  it('should not treat join conditions as a field', () => {
+    const filter: Filter<Test> = {
+      strField: { eq: '' },
+      testRelation: {
+        on: { boolField: { is: false } }
+      }
+    }
+    expect(getFilterFields(filter).sort()).toEqual(['strField', 'testRelation'])
+    expect(getFilterFields(filter.testRelation as Filter<Test>)).toEqual([])
   })
 })
 

--- a/packages/core/src/helpers/filter.builder.ts
+++ b/packages/core/src/helpers/filter.builder.ts
@@ -1,6 +1,6 @@
 import { Filter, FilterComparisons, FilterFieldComparison } from '../interfaces'
 import { ComparisonBuilder } from './comparison.builder'
-import { getFilterFieldComparison, isComparison } from './filter.helpers'
+import { getFilterFieldComparison, isComparison, ON_CONDITION_KEY } from './filter.helpers'
 import { ComparisonField, FilterFn } from './types'
 
 export class FilterBuilder {
@@ -32,7 +32,7 @@ export class FilterBuilder {
   private static filterFieldsOrNested<DTO>(filter: Filter<DTO>): FilterFn<DTO> {
     return this.andFilterFn(
       ...Object.keys(filter)
-        .filter((k) => k !== 'and' && k !== 'or')
+        .filter((k) => k !== 'and' && k !== 'or' && k !== ON_CONDITION_KEY)
         .map((fieldOrNested) => this.withComparison(filter, fieldOrNested as keyof DTO))
     )
   }

--- a/packages/core/src/helpers/filter.helpers.ts
+++ b/packages/core/src/helpers/filter.helpers.ts
@@ -2,6 +2,14 @@ import { Filter, FilterComparisons, FilterFieldComparison } from '../interfaces'
 import { FilterBuilder } from './filter.builder'
 import { QueryFieldMap } from './query.helpers'
 
+/**
+ * The reserved filter key that holds a relation's `JOIN ... ON` conditions.
+ *
+ * It is not a field or relation name and is therefore skipped when collecting the fields a filter
+ * references.
+ */
+export const ON_CONDITION_KEY = 'on'
+
 export type LikeComparisonOperators = 'like' | 'notLike' | 'iLike' | 'notILike'
 export type InComparisonOperators = 'in' | 'notIn'
 export type BetweenComparisonOperators = 'between' | 'notBetween'
@@ -98,7 +106,7 @@ export const getFilterFields = <DTO>(filter: Filter<DTO>): string[] => {
           fields
         )
       }
-    } else {
+    } else if (filterField !== ON_CONDITION_KEY) {
       fields.add(filterField)
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   mergeFilter,
   mergeFilters,
   mergeQuery,
+  ON_CONDITION_KEY,
   QueryFieldMap,
   transformAggregateQuery,
   transformAggregateResponse,

--- a/packages/core/src/interfaces/filter.interface.ts
+++ b/packages/core/src/interfaces/filter.interface.ts
@@ -65,6 +65,52 @@ type FilterGrouping<T> = {
 }
 
 /**
+ * Conditions that are injected into a relation's SQL `JOIN ... ON` clause instead of the `WHERE`
+ * clause.
+ *
+ * Only comparisons on the joined relation's own fields are allowed, optionally grouped with
+ * `and`/`or`. Nested relations are not, because a join condition can only reference the relation
+ * being joined.
+ *
+ * @example
+ * ```ts
+ * // LEFT JOIN "sub_task" ON "sub_task"."task_id" = "task"."id" AND ("sub_task"."completed" = FALSE)
+ * const filter: Filter<Task> = {
+ *   subTasks: {
+ *     on: { completed: { is: false } },
+ *   },
+ * }
+ * ```
+ *
+ * @typeparam T - the type of object the join condition applies to.
+ */
+export type OnConditionFilter<T> = FilterComparisons<T> & {
+  /**
+   * Group an array of join conditions with an AND operation.
+   */
+  and?: OnConditionFilter<T>[]
+  /**
+   * Group an array of join conditions with an OR operation.
+   */
+  or?: OnConditionFilter<T>[]
+}
+
+/**
+ * The join conditions of a relation filter.
+ */
+type FilterJoinConditions<T> = {
+  /**
+   * Conditions to inject into this relation's SQL `JOIN ... ON` clause rather than the `WHERE`
+   * clause, which preserves `LEFT JOIN` semantics so parent rows without a matching child are
+   * kept.
+   *
+   * Only honoured at the top level of a relation filter. An `on` at the root filter level, or
+   * inside an `and`/`or` expression, has no join to attach to and is rejected.
+   */
+  on?: OnConditionFilter<T>
+}
+
+/**
  * Filter for type T.
  *
  * @example
@@ -110,6 +156,16 @@ type FilterGrouping<T> = {
  * }
  * ```
  *
+ * @example
+ * ```ts
+ * // LEFT JOIN "sub_task" ON "sub_task"."task_id" = "task"."id" AND ("sub_task"."completed" = FALSE)
+ * const filter: Filter<Task> = {
+ *   subTasks: {
+ *     on: { completed: { is: false } },
+ *   },
+ * }
+ * ```
+ *
  * @typeparam T - the type of object to filter on.
  */
-export type Filter<T> = FilterGrouping<T> & FilterComparisons<T>
+export type Filter<T> = FilterGrouping<T> & FilterComparisons<T> & FilterJoinConditions<T>

--- a/packages/query-graphql/__tests__/types/query/__snapshots__/filter.type.spec.ts.snap
+++ b/packages/query-graphql/__tests__/types/query/__snapshots__/filter.type.spec.ts.snap
@@ -888,6 +888,11 @@ input TestFilterDepth_ShouldNotAffect_RelationADeepFilter {
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
   filterableRelation: TestRelationDtoDeepFilter
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter
 }
 
 input StringFieldComparison {
@@ -913,6 +918,27 @@ input TestRelationDtoDeepFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
+}
+
+input TestRelationDtoOnConditionFilter {
+  and: [TestRelationDtoOnConditionFilter!]
+  or: [TestRelationDtoOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+}
+
+input TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter {
+  and: [TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter!]
+  or: [TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
 }
 
 input TestFilterDepth_ShouldNotAffect_RelationAFilter {
@@ -930,6 +956,11 @@ input TestFilterDepth_ShouldNotAffect_RelationAFilterTestRelationDtoFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
 }"
 `;
 
@@ -1081,6 +1112,11 @@ input TestFilterDepth_1FilterTestFilterDepth_1_RelationAFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestFilterDepth_1_RelationAOnConditionFilter
 }
 
 input StringFieldComparison {
@@ -1098,6 +1134,14 @@ input StringFieldComparison {
   notILike: String
   in: [String!]
   notIn: [String!]
+}
+
+input TestFilterDepth_1_RelationAOnConditionFilter {
+  and: [TestFilterDepth_1_RelationAOnConditionFilter!]
+  or: [TestFilterDepth_1_RelationAOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
 }"
 `;
 
@@ -1179,6 +1223,11 @@ input TestFilterDepth_2FilterTestFilterDepth_2_RelationAFilter {
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
   filterableRelation: TestFilterDepth_2FilterTestFilterDepth_2_RelationAFilterTestRelationDtoFilter
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestFilterDepth_2_RelationAOnConditionFilter
 }
 
 input StringFieldComparison {
@@ -1201,6 +1250,27 @@ input StringFieldComparison {
 input TestFilterDepth_2FilterTestFilterDepth_2_RelationAFilterTestRelationDtoFilter {
   and: [TestFilterDepth_2FilterTestFilterDepth_2_RelationAFilterTestRelationDtoFilter!]
   or: [TestFilterDepth_2FilterTestFilterDepth_2_RelationAFilterTestRelationDtoFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
+}
+
+input TestRelationDtoOnConditionFilter {
+  and: [TestRelationDtoOnConditionFilter!]
+  or: [TestRelationDtoOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+}
+
+input TestFilterDepth_2_RelationAOnConditionFilter {
+  and: [TestFilterDepth_2_RelationAOnConditionFilter!]
+  or: [TestFilterDepth_2_RelationAOnConditionFilter!]
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
@@ -1285,6 +1355,11 @@ input TestFilterDepth_Infinite_RelationADeepFilter {
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
   filterableRelation: TestRelationDtoDeepFilter
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestFilterDepth_Infinite_RelationAOnConditionFilter
 }
 
 input StringFieldComparison {
@@ -1307,6 +1382,27 @@ input StringFieldComparison {
 input TestRelationDtoDeepFilter {
   and: [TestRelationDtoDeepFilter!]
   or: [TestRelationDtoDeepFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
+}
+
+input TestRelationDtoOnConditionFilter {
+  and: [TestRelationDtoOnConditionFilter!]
+  or: [TestRelationDtoOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+}
+
+input TestFilterDepth_Infinite_RelationAOnConditionFilter {
+  and: [TestFilterDepth_Infinite_RelationAOnConditionFilter!]
+  or: [TestFilterDepth_Infinite_RelationAOnConditionFilter!]
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
@@ -1491,6 +1587,11 @@ input TestFilterDepth_ShouldNotAffect_RelationADeepFilter {
   relationAge: NumberFieldComparison
   filterableRelation2: TestRelationDtoDeepFilter
   filterableRelation1: TestRelationDtoDeepFilter
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter
 }
 
 input StringFieldComparison {
@@ -1516,6 +1617,27 @@ input TestRelationDtoDeepFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
+}
+
+input TestRelationDtoOnConditionFilter {
+  and: [TestRelationDtoOnConditionFilter!]
+  or: [TestRelationDtoOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+}
+
+input TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter {
+  and: [TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter!]
+  or: [TestFilterDepth_ShouldNotAffect_RelationAOnConditionFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
 }
 
 input TestFilterDepth_ShouldNotAffect_RelationAFilter {
@@ -1534,6 +1656,11 @@ input TestFilterDepth_ShouldNotAffect_RelationAFilterTestRelationDtoFilter {
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
 }"
 `;
 
@@ -1870,6 +1997,19 @@ input TimestampFieldComparisonBetween {
 input TestFilterDtoFilterTestRelationDtoFilter {
   and: [TestFilterDtoFilterTestRelationDtoFilter!]
   or: [TestFilterDtoFilterTestRelationDtoFilter!]
+  id: NumberFieldComparison
+  relationName: StringFieldComparison
+  relationAge: NumberFieldComparison
+
+  """
+  Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only honoured at the top level of a relation filter: an \`on\` placed at the root filter level or inside an \`and\`/\`or\` expression is rejected.
+  """
+  on: TestRelationDtoOnConditionFilter
+}
+
+input TestRelationDtoOnConditionFilter {
+  and: [TestRelationDtoOnConditionFilter!]
+  or: [TestRelationDtoOnConditionFilter!]
   id: NumberFieldComparison
   relationName: StringFieldComparison
   relationAge: NumberFieldComparison

--- a/packages/query-graphql/__tests__/types/query/filter.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/query/filter.type.spec.ts
@@ -176,6 +176,18 @@ describe('filter types', (): void => {
       expect(filterInstance.or[0]).toBeInstanceOf(TestGraphQLFilter)
     })
 
+    it('should convert relation join conditions to filter class', () => {
+      const filterObject = {
+        filterableRelation: { on: { relationName: { eq: 'foo' } } }
+      } as Filter<TestDto>
+
+      const filterInstance = plainToClass(TestDtoFilter, filterObject) as Record<string, Filter<TestRelation>>
+      const relationFilter = filterInstance.filterableRelation
+
+      expect(relationFilter.on.relationName.eq).toBe('foo')
+      expect(relationFilter.on.constructor.name).toBe('GraphQLFilter')
+    })
+
     it('should create filter for sub objects', () => {
       @ObjectType('TestSubObjectType')
       class TestSubObjectType {

--- a/packages/query-graphql/src/types/query/filter.type.ts
+++ b/packages/query-graphql/src/types/query/filter.type.ts
@@ -32,6 +32,8 @@ export type FilterableRelations = Record<string, Class<unknown>>
 export interface FilterConstructor<T> {
   hasRequiredFilters: boolean
 
+  prototype: object
+
   new (): Filter<T>
 }
 
@@ -60,7 +62,7 @@ function getFilterableRelations(relations: Record<string, ResolverRelation<unkno
  * ever declared once per type.
  */
 function addOnConditionField<T>(RelationFilter: FilterConstructor<T>, OnConditionFilter: FilterConstructor<T>): void {
-  const filterPrototype = (RelationFilter as unknown as { prototype: object }).prototype
+  const filterPrototype = RelationFilter.prototype
 
   if (filterTypesWithOnCondition.has(filterPrototype)) {
     return

--- a/packages/query-graphql/src/types/query/filter.type.ts
+++ b/packages/query-graphql/src/types/query/filter.type.ts
@@ -15,6 +15,12 @@ const reflector = new MapReflector('nestjs-query:filter-type')
 // e.g. if there is a circular reference in the relations
 //      `User -> Post -> User-> Post -> ...`
 const internalCache = new Map<Class<unknown>, Map<string, FilterConstructor<unknown>>>()
+// filter types are memoized and can be reached through more than one relation, so the `on` field
+// is only ever declared once per type
+const filterTypesWithOnCondition = new WeakSet<object>()
+
+const ON_CONDITION_FIELD = 'on'
+const ON_CONDITION_TYPE_SUFFIX = 'OnCondition'
 
 export type FilterTypeOptions = {
   allowedBooleanExpressions?: ('and' | 'or')[]
@@ -42,6 +48,35 @@ function getFilterableRelations(relations: Record<string, ResolverRelation<unkno
     }
   })
   return filterableRelations
+}
+
+/**
+ * Adds the `on` field to a filter type that is used as a relation filter.
+ *
+ * Conditions under `on` end up in the relation's `JOIN ... ON` clause, so the field is typed with a
+ * depth zero filter and therefore cannot itself reference further relations.
+ *
+ * Filter types are memoized and can be reached through more than one relation, so the field is only
+ * ever declared once per type.
+ */
+function addOnConditionField<T>(RelationFilter: FilterConstructor<T>, OnConditionFilter: FilterConstructor<T>): void {
+  const filterPrototype = (RelationFilter as unknown as { prototype: object }).prototype
+
+  if (filterTypesWithOnCondition.has(filterPrototype)) {
+    return
+  }
+  filterTypesWithOnCondition.add(filterPrototype)
+
+  ValidateNested()(filterPrototype, ON_CONDITION_FIELD)
+  Field(() => OnConditionFilter, {
+    nullable: true,
+    description:
+      "Conditions injected into this relation's JOIN ON clause rather than the WHERE clause, " +
+      'preserving LEFT JOIN semantics so parent rows without a matching child are kept. Only ' +
+      'honoured at the top level of a relation filter: an `on` placed at the root filter level or ' +
+      'inside an `and`/`or` expression is rejected.'
+  })(filterPrototype, ON_CONDITION_FIELD)
+  Type(() => OnConditionFilter)(filterPrototype, ON_CONDITION_FIELD)
 }
 
 function getOrCreateFilterType<T>(
@@ -136,6 +171,8 @@ function getOrCreateFilterType<T>(
 
         if (FieldType) {
           const FC = getOrCreateFilterType(FieldType, newPrefix, suffix, depth - 1)
+
+          addOnConditionField(FC, getOrCreateFilterType(FieldType, '', ON_CONDITION_TYPE_SUFFIX, 0))
 
           ValidateNested()(GraphQLFilter.prototype, field)
           Field(() => FC, { nullable: true })(GraphQLFilter.prototype, field)

--- a/packages/query-typeorm/__tests__/query/__snapshots__/filter-query.builder.spec.ts.snap
+++ b/packages/query-typeorm/__tests__/query/__snapshots__/filter-query.builder.spec.ts.snap
@@ -263,6 +263,132 @@ FROM
   LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk""
 `;
 
+exports[`FilterQueryBuilder #select with relation join conditions should add the join conditions of a nested relation 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN (
+    "test_relation" "oneTestRelation"
+    LEFT JOIN "relation_of_test_relation_entity" "relationsOfTestRelation" ON "relationsOfTestRelation"."test_relation_id" = "oneTestRelation"."test_relation_pk"
+    AND (
+      "relationsOfTestRelation"."test_relation_id" IS NULL
+    )
+  ) ON "oneTestRelation"."test_relation_pk" = "TestEntity"."oneTestRelationTestRelationPk"
+  AND ("oneTestRelation"."relation_name" = foo)
+WHERE
+  (1 = 1)"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should add the join conditions to a selected relation 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk",
+  "oneTestRelation"."test_relation_pk" AS "oneTestRelation_test_relation_pk",
+  "oneTestRelation"."relation_name" AS "oneTestRelation_relation_name",
+  "oneTestRelation"."test_entity_id" AS "oneTestRelation_test_entity_id",
+  "oneTestRelation"."uni_directional_test_entity_id" AS "oneTestRelation_uni_directional_test_entity_id",
+  "oneTestRelation"."uni_directional_relation_test_entity_id" AS "oneTestRelation_uni_directional_relation_test_entity_id"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "oneTestRelation" ON "oneTestRelation"."test_relation_pk" = "TestEntity"."oneTestRelationTestRelationPk"
+  AND ("oneTestRelation"."relation_name" = foo)"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should add the join conditions to the LEFT JOIN instead of the WHERE clause 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND ("testRelations"."relation_name" = foo)"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should keep filtering in the WHERE clause for the same relation 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND ("testRelations"."relation_name" = foo)
+WHERE
+  (("testRelations"."test_relation_pk" IS NOT NULL))"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should merge the join conditions when the same relation is referenced twice 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND (
+    (
+      "testRelations"."relation_name" = foo
+      AND "testRelations"."test_entity_id" IS NULL
+    )
+  )
+WHERE
+  (
+    (1 = 1)
+    AND (1 = 1)
+  )"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should support boolean expressions inside the join conditions 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND (
+    (
+      "testRelations"."relation_name" = foo
+      OR "testRelations"."test_entity_id" IS NULL
+    )
+  )"
+`;
+
 exports[`FilterQueryBuilder #select with relation should select and map relation 1`] = `
 "SELECT
   "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",

--- a/packages/query-typeorm/__tests__/query/__snapshots__/filter-query.builder.spec.ts.snap
+++ b/packages/query-typeorm/__tests__/query/__snapshots__/filter-query.builder.spec.ts.snap
@@ -113,6 +113,26 @@ OFFSET
   11"
 `;
 
+exports[`FilterQueryBuilder #select with paging skip/take - limit/offset should use limit/offset when a one to one relation only has join conditions 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "oneTestRelation" ON "oneTestRelation"."test_relation_pk" = "TestEntity"."oneTestRelationTestRelationPk"
+  AND ("oneTestRelation"."relation_name" = foo)
+LIMIT
+  10
+OFFSET
+  3"
+`;
+
 exports[`FilterQueryBuilder #select with paging skip/take - limit/offset should use limit/offset when filtering on many to one relation 1`] = `
 "SELECT
   "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
@@ -193,6 +213,22 @@ LIMIT
   10
 OFFSET
   3"
+`;
+
+exports[`FilterQueryBuilder #select with paging skip/take - limit/offset should use skip/take when a one to many relation only has join conditions 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND ("testRelations"."relation_name" = foo)"
 `;
 
 exports[`FilterQueryBuilder #select with paging skip/take - limit/offset should use skip/take when filtering on many to many relation 1`] = `
@@ -322,6 +358,38 @@ FROM
   "test_entity" "TestEntity"
   LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
   AND ("testRelations"."relation_name" = foo)"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should bind a between comparison in the join conditions 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND ("testRelations"."relation_name" BETWEEN a AND z)"
+`;
+
+exports[`FilterQueryBuilder #select with relation join conditions should bind an in comparison in the join conditions 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+  LEFT JOIN "test_relation" "testRelations" ON "testRelations"."test_entity_id" = "TestEntity"."test_entity_pk"
+  AND ("testRelations"."relation_name" IN (foo, bar))"
 `;
 
 exports[`FilterQueryBuilder #select with relation join conditions should keep filtering in the WHERE clause for the same relation 1`] = `

--- a/packages/query-typeorm/__tests__/query/__snapshots__/where.builder.spec.ts.snap
+++ b/packages/query-typeorm/__tests__/query/__snapshots__/where.builder.spec.ts.snap
@@ -113,6 +113,38 @@ WHERE
   )"
 `;
 
+exports[`WhereBuilder join conditions should not add a relations join conditions to the where clause 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+WHERE
+  ((testRelations.testRelationPk = foo))"
+`;
+
+exports[`WhereBuilder join conditions should not add join conditions to the where clause 1`] = `
+"SELECT
+  "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",
+  "TestEntity"."string_type" AS "TestEntity_string_type",
+  "TestEntity"."bool_type" AS "TestEntity_bool_type",
+  "TestEntity"."number_type" AS "TestEntity_number_type",
+  "TestEntity"."date_type" AS "TestEntity_date_type",
+  "TestEntity"."many_to_one_relation_id" AS "TestEntity_many_to_one_relation_id",
+  "TestEntity"."many_to_one_soft_delete_relation_id" AS "TestEntity_many_to_one_soft_delete_relation_id",
+  "TestEntity"."oneTestRelationTestRelationPk" AS "TestEntity_oneTestRelationTestRelationPk"
+FROM
+  "test_entity" "TestEntity"
+WHERE
+  ("TestEntity"."string_type" = foo)"
+`;
+
 exports[`WhereBuilder or and multiple and filters together 1`] = `
 "SELECT
   "TestEntity"."test_entity_pk" AS "TestEntity_test_entity_pk",

--- a/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
@@ -187,7 +187,7 @@ describe('FilterQueryBuilder', (): void => {
       const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
       const qb = getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder))
       expect(qb.getReferencedRelationsRecursive(qb.repo.metadata, complexQuery)).toEqual({
-        oneTestRelation: { relationOfTestRelation: {} }
+        oneTestRelation: { children: { relationOfTestRelation: { children: {} } } }
       })
     })
     it('with nested and / or', () => {
@@ -226,7 +226,10 @@ describe('FilterQueryBuilder', (): void => {
             }
           ]
         } as Filter<TestEntity>)
-      ).toEqual({ testRelations: {}, oneTestRelation: { relationsOfTestRelation: {} } })
+      ).toEqual({
+        testRelations: { children: {} },
+        oneTestRelation: { children: { relationsOfTestRelation: { children: {} } } }
+      })
     })
   })
 
@@ -277,6 +280,79 @@ describe('FilterQueryBuilder', (): void => {
             }
           ]
         } as any)
+      })
+    })
+
+    describe('with relation join conditions', () => {
+      const expectJoinConditionSQLSnapshot = (query: Query<TestEntity>): void => {
+        expectSQLSnapshot(new FilterQueryBuilder(connection.getRepository(TestEntity)).select(query))
+      }
+
+      it('should add the join conditions to the LEFT JOIN instead of the WHERE clause', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: { testRelations: { on: { relationName: { eq: 'foo' } } } }
+        })
+      })
+
+      it('should keep filtering in the WHERE clause for the same relation', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: { testRelations: { on: { relationName: { eq: 'foo' } }, testRelationPk: { isNot: null } } }
+        })
+      })
+
+      it('should support boolean expressions inside the join conditions', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: {
+            testRelations: {
+              on: { or: [{ relationName: { eq: 'foo' } }, { testEntityId: { is: null } }] }
+            }
+          }
+        })
+      })
+
+      it('should add the join conditions of a nested relation', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: {
+            oneTestRelation: {
+              on: { relationName: { eq: 'foo' } },
+              relationsOfTestRelation: { on: { testRelationId: { is: null } } }
+            }
+          }
+        })
+      })
+
+      it('should merge the join conditions when the same relation is referenced twice', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: {
+            and: [
+              { testRelations: { on: { relationName: { eq: 'foo' } } } },
+              { testRelations: { on: { testEntityId: { is: null } } } }
+            ]
+          }
+        })
+      })
+
+      it('should add the join conditions to a selected relation', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: { oneTestRelation: { on: { relationName: { eq: 'foo' } } } },
+          relations: [{ name: 'oneTestRelation', query: {} }]
+        } as Query<TestEntity>)
+      })
+
+      it('should throw when join conditions are at the root filter level', () => {
+        expect(() => expectJoinConditionSQLSnapshot({ filter: { on: { stringType: { eq: 'foo' } } } })).toThrow(
+          '`on` conditions are only supported at the top level of a relation filter, not at the root filter level.'
+        )
+      })
+
+      it('should throw when join conditions are inside a boolean expression', () => {
+        expect(() =>
+          expectJoinConditionSQLSnapshot({
+            filter: { testRelations: { and: [{ on: { relationName: { eq: 'foo' } } }] } }
+          })
+        ).toThrow(
+          '`on` conditions are only supported at the top level of a relation filter, not inside an `and`/`or` expression.'
+        )
       })
     })
 

--- a/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/filter-query.builder.spec.ts
@@ -1,4 +1,4 @@
-import { Class, Filter, Query, SortDirection, SortNulls } from '@ptc-org/nestjs-query-core'
+import { Class, Filter, Query, SelectRelation, SortDirection, SortNulls } from '@ptc-org/nestjs-query-core'
 import { format as formatSql } from 'sql-formatter'
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito'
 import { DataSource, QueryBuilder, WhereExpressionBuilder } from 'typeorm'
@@ -190,6 +190,13 @@ describe('FilterQueryBuilder', (): void => {
         oneTestRelation: { children: { relationOfTestRelation: { children: {} } } }
       })
     })
+    it('with a selected relation that is not a relation of the entity', () => {
+      const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+      const qb = getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder))
+      const selectRelations = [{ name: 'stringType', query: {} }] as SelectRelation<TestEntity>[]
+
+      expect(qb.getReferencedRelationsRecursive(qb.repo.metadata, {}, selectRelations)).toEqual({})
+    })
     it('with nested and / or', () => {
       const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
       const qb = getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder))
@@ -339,6 +346,18 @@ describe('FilterQueryBuilder', (): void => {
         } as Query<TestEntity>)
       })
 
+      it('should bind an in comparison in the join conditions', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: { testRelations: { on: { relationName: { in: ['foo', 'bar'] } } } }
+        })
+      })
+
+      it('should bind a between comparison in the join conditions', () => {
+        expectJoinConditionSQLSnapshot({
+          filter: { testRelations: { on: { relationName: { between: { lower: 'a', upper: 'z' } } } } }
+        })
+      })
+
       it('should throw when join conditions are at the root filter level', () => {
         expect(() => expectJoinConditionSQLSnapshot({ filter: { on: { stringType: { eq: 'foo' } } } })).toThrow(
           '`on` conditions are only supported at the top level of a relation filter, not at the root filter level.'
@@ -476,6 +495,62 @@ describe('FilterQueryBuilder', (): void => {
             {
               paging: { limit: 10, offset: 3 },
               filter: { manyToOneRelation: { testRelationPk: { eq: 'test' } } }
+            },
+            instance(mockWhereBuilder)
+          )
+        })
+
+        const selectPagedByJoinConditions = (relation: keyof TestEntity) => {
+          const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+          when(mockWhereBuilder.build(anything(), anything(), anything(), anything())).thenCall(
+            (qb: WhereExpressionBuilder) => qb
+          )
+
+          return getEntityQueryBuilder(TestEntity, instance(mockWhereBuilder)).select({
+            paging: { limit: 10, offset: 3 },
+            filter: { [relation]: { on: { relationName: { eq: 'foo' } } } }
+          }).expressionMap
+        }
+
+        it('should page a one to many relation with only join conditions by skip/take', () => {
+          const { take, skip, limit, offset } = selectPagedByJoinConditions('testRelations')
+
+          expect({ take, skip }).toEqual({ take: 10, skip: 3 })
+          expect({ limit, offset }).toEqual({ limit: undefined, offset: undefined })
+        })
+
+        it('should page a one to one relation with only join conditions by limit/offset', () => {
+          const { take, skip, limit, offset } = selectPagedByJoinConditions('oneTestRelation')
+
+          expect({ limit, offset }).toEqual({ limit: 10, offset: 3 })
+          expect({ take, skip }).toEqual({ take: undefined, skip: undefined })
+        })
+
+        it('should use skip/take when a one to many relation only has join conditions', () => {
+          const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+          when(mockWhereBuilder.build(anything(), anything(), anything(), anything())).thenCall(
+            (qb: WhereExpressionBuilder) => qb
+          )
+
+          expectSelectSQLSnapshot(
+            {
+              paging: { limit: 10, offset: 3 },
+              filter: { testRelations: { on: { relationName: { eq: 'foo' } } } }
+            },
+            instance(mockWhereBuilder)
+          )
+        })
+
+        it('should use limit/offset when a one to one relation only has join conditions', () => {
+          const mockWhereBuilder = mock<WhereBuilder<TestEntity>>(WhereBuilder)
+          when(mockWhereBuilder.build(anything(), anything(), anything(), anything())).thenCall(
+            (qb: WhereExpressionBuilder) => qb
+          )
+
+          expectSelectSQLSnapshot(
+            {
+              paging: { limit: 10, offset: 3 },
+              filter: { oneTestRelation: { on: { relationName: { eq: 'foo' } } } }
             },
             instance(mockWhereBuilder)
           )

--- a/packages/query-typeorm/__tests__/query/on-condition.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/on-condition.builder.spec.ts
@@ -62,6 +62,41 @@ describe('OnConditionBuilder', (): void => {
     expect(Object.values(params)).toEqual([10, 20])
   })
 
+  it('should spread an in comparison and bind the values as a single parameter', (): void => {
+    const { condition, params } = buildOnCondition({ numberType: { in: [1, 2, 3] } })
+
+    expect(withStableParamNames(condition)).toBe('TestEntity.numberType IN (:...param)')
+    expect(Object.values(params)).toEqual([[1, 2, 3]])
+  })
+
+  it('should spread a notIn comparison and bind the values as a single parameter', (): void => {
+    const { condition, params } = buildOnCondition({ numberType: { notIn: [1, 2, 3] } })
+
+    expect(withStableParamNames(condition)).toBe('TestEntity.numberType NOT IN (:...param)')
+    expect(Object.values(params)).toEqual([[1, 2, 3]])
+  })
+
+  it('should bind both bounds of a between comparison', (): void => {
+    const { condition, params } = buildOnCondition({ numberType: { between: { lower: 1, upper: 10 } } })
+
+    expect(withStableParamNames(condition)).toBe('TestEntity.numberType BETWEEN :param AND :param')
+    expect(Object.keys(params)).toHaveLength(2)
+    expect(Object.values(params)).toEqual([1, 10])
+  })
+
+  it('should keep both bounds of a between comparison when merged with another field', (): void => {
+    const { condition, params } = buildOnCondition({
+      numberType: { between: { lower: 1, upper: 10 } },
+      stringType: { eq: 'foo' }
+    })
+
+    expect(withStableParamNames(condition)).toBe(
+      '(TestEntity.numberType BETWEEN :param AND :param AND TestEntity.stringType = :param)'
+    )
+    expect(Object.keys(params)).toHaveLength(3)
+    expect(Object.values(params)).toEqual([1, 10, 'foo'])
+  })
+
   describe('and', (): void => {
     it('should and multiple expressions together', (): void => {
       const { condition } = buildOnCondition({ and: [{ boolType: { is: true } }, { dateType: { is: null } }] })

--- a/packages/query-typeorm/__tests__/query/on-condition.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/on-condition.builder.spec.ts
@@ -1,0 +1,113 @@
+import { OnConditionFilter } from '@ptc-org/nestjs-query-core'
+
+import { OnConditionBuilder, OnConditionSQL } from '../../src/query'
+import { TestEntity } from '../__fixtures__/test.entity'
+
+describe('OnConditionBuilder', (): void => {
+  const createOnConditionBuilder = () => new OnConditionBuilder<TestEntity>()
+
+  const buildOnCondition = (onCondition?: OnConditionFilter<TestEntity>): OnConditionSQL =>
+    createOnConditionBuilder().build(onCondition, 'TestEntity')
+
+  const withStableParamNames = (condition?: string): string | undefined =>
+    condition?.replace(/:\.\.\.param\w+/g, ':...param').replace(/:param\w+/g, ':param')
+
+  it('should return an empty condition when there are no join conditions', (): void => {
+    expect(buildOnCondition(undefined)).toEqual({ condition: undefined, params: undefined })
+  })
+
+  it('should return an empty condition for an empty filter', (): void => {
+    expect(buildOnCondition({})).toEqual({ condition: undefined, params: undefined })
+  })
+
+  it('should return an empty condition when a comparison is not an object', (): void => {
+    expect(buildOnCondition({ stringType: 'foo' } as unknown as OnConditionFilter<TestEntity>)).toEqual({
+      condition: undefined,
+      params: undefined
+    })
+  })
+
+  it('should qualify the compared field with the relation alias', (): void => {
+    const { condition, params } = buildOnCondition({ numberType: { eq: 1 } })
+
+    expect(withStableParamNames(condition)).toBe('TestEntity.numberType = :param')
+    expect(Object.values(params)).toEqual([1])
+  })
+
+  it('should bind values as parameters instead of interpolating them', (): void => {
+    const { condition, params } = buildOnCondition({ stringType: { eq: "foo'; DROP TABLE test_entity; --" } })
+
+    expect(condition).not.toContain('DROP TABLE')
+    expect(Object.values(params)).toEqual(["foo'; DROP TABLE test_entity; --"])
+  })
+
+  it('should not bind parameters for is comparisons', (): void => {
+    const { condition, params } = buildOnCondition({ boolType: { is: false } })
+
+    expect(condition).toBe('TestEntity.boolType = FALSE')
+    expect(params).toEqual({})
+  })
+
+  it('should and multiple field comparisons together', (): void => {
+    const { condition, params } = buildOnCondition({ boolType: { is: false }, dateType: { is: null } })
+
+    expect(condition).toBe('(TestEntity.boolType = FALSE AND TestEntity.dateType IS NULL)')
+    expect(params).toEqual({})
+  })
+
+  it('should or multiple operators for a single field together', (): void => {
+    const { condition, params } = buildOnCondition({ numberType: { gt: 10, lt: 20 } })
+
+    expect(withStableParamNames(condition)).toBe('(TestEntity.numberType > :param OR TestEntity.numberType < :param)')
+    expect(Object.values(params)).toEqual([10, 20])
+  })
+
+  describe('and', (): void => {
+    it('should and multiple expressions together', (): void => {
+      const { condition } = buildOnCondition({ and: [{ boolType: { is: true } }, { dateType: { is: null } }] })
+
+      expect(condition).toBe('(TestEntity.boolType = TRUE AND TestEntity.dateType IS NULL)')
+    })
+
+    it('should ignore a non array value', (): void => {
+      expect(buildOnCondition({ and: {} } as unknown as OnConditionFilter<TestEntity>)).toEqual({
+        condition: undefined,
+        params: undefined
+      })
+    })
+  })
+
+  describe('or', (): void => {
+    it('should or multiple expressions together', (): void => {
+      const { condition } = buildOnCondition({ or: [{ boolType: { is: true } }, { dateType: { is: null } }] })
+
+      expect(condition).toBe('(TestEntity.boolType = TRUE OR TestEntity.dateType IS NULL)')
+    })
+
+    it('should support nested ands', (): void => {
+      const { condition } = buildOnCondition({
+        or: [{ and: [{ boolType: { is: true } }, { dateType: { is: null } }] }, { boolType: { is: false } }]
+      })
+
+      expect(condition).toBe('((TestEntity.boolType = TRUE AND TestEntity.dateType IS NULL) OR TestEntity.boolType = FALSE)')
+    })
+
+    it('should and a boolean expression with a sibling field comparison', (): void => {
+      const { condition } = buildOnCondition({
+        boolType: { is: false },
+        or: [{ dateType: { is: null } }, { dateType: { isNot: null } }]
+      })
+
+      expect(condition).toBe('(TestEntity.boolType = FALSE AND (TestEntity.dateType IS NULL OR TestEntity.dateType IS NOT NULL))')
+    })
+  })
+
+  it('should merge the parameters of every comparison', (): void => {
+    const { params } = buildOnCondition({
+      numberType: { eq: 1 },
+      and: [{ stringType: { eq: 'foo' } }, { or: [{ stringType: { eq: 'bar' } }] }]
+    })
+
+    expect(Object.values(params).sort()).toEqual([1, 'bar', 'foo'])
+  })
+})

--- a/packages/query-typeorm/__tests__/query/on-condition.validator.spec.ts
+++ b/packages/query-typeorm/__tests__/query/on-condition.validator.spec.ts
@@ -1,0 +1,58 @@
+import { Filter } from '@ptc-org/nestjs-query-core'
+
+import { assertValidOnConditionPlacement, InvalidOnConditionPlacementError } from '../../src/query'
+import { TestEntity } from '../__fixtures__/test.entity'
+
+describe('assertValidOnConditionPlacement', (): void => {
+  const assertPlacement = (filter: Filter<TestEntity>) => () => assertValidOnConditionPlacement(filter)
+
+  it('should accept a filter without join conditions', (): void => {
+    expect(assertPlacement({ stringType: { eq: 'foo' } })).not.toThrow()
+  })
+
+  it('should accept join conditions at the top level of a relation filter', (): void => {
+    expect(assertPlacement({ testRelations: { on: { relationName: { eq: 'foo' } } } })).not.toThrow()
+  })
+
+  it('should accept join conditions on a nested relation filter', (): void => {
+    expect(
+      assertPlacement({
+        oneTestRelation: { on: { relationName: { eq: 'foo' } }, testEntity: { on: { boolType: { is: true } } } }
+      })
+    ).not.toThrow()
+  })
+
+  it('should accept join conditions on a relation nested inside an and', (): void => {
+    expect(assertPlacement({ and: [{ testRelations: { on: { relationName: { eq: 'foo' } } } }] })).not.toThrow()
+  })
+
+  it('should reject join conditions at the root filter level', (): void => {
+    expect(assertPlacement({ on: { stringType: { eq: 'foo' } } })).toThrow(
+      '`on` conditions are only supported at the top level of a relation filter, not at the root filter level.'
+    )
+  })
+
+  it('should reject join conditions inside an and', (): void => {
+    expect(assertPlacement({ testRelations: { and: [{ on: { relationName: { eq: 'foo' } } }] } })).toThrow(
+      '`on` conditions are only supported at the top level of a relation filter, not inside an `and`/`or` expression.'
+    )
+  })
+
+  it('should reject join conditions inside an or', (): void => {
+    expect(assertPlacement({ testRelations: { or: [{ on: { relationName: { eq: 'foo' } } }] } })).toThrow(
+      '`on` conditions are only supported at the top level of a relation filter, not inside an `and`/`or` expression.'
+    )
+  })
+
+  it('should reject join conditions nested deeply inside a boolean expression', (): void => {
+    expect(
+      assertPlacement({
+        and: [{ or: [{ testRelations: { and: [{ on: { relationName: { eq: 'foo' } } }] } }] }]
+      })
+    ).toThrow(InvalidOnConditionPlacementError)
+  })
+
+  it('should throw an InvalidOnConditionPlacementError', (): void => {
+    expect(assertPlacement({ on: { stringType: { eq: 'foo' } } })).toThrow(InvalidOnConditionPlacementError)
+  })
+})

--- a/packages/query-typeorm/__tests__/query/on-condition.validator.spec.ts
+++ b/packages/query-typeorm/__tests__/query/on-condition.validator.spec.ts
@@ -26,6 +26,22 @@ describe('assertValidOnConditionPlacement', (): void => {
     expect(assertPlacement({ and: [{ testRelations: { on: { relationName: { eq: 'foo' } } } }] })).not.toThrow()
   })
 
+  it('should skip a non array and value', (): void => {
+    expect(
+      assertPlacement({
+        testRelations: { and: { on: { relationName: { eq: 'foo' } } } }
+      } as unknown as Filter<TestEntity>)
+    ).not.toThrow()
+  })
+
+  it('should skip a non array or value', (): void => {
+    expect(
+      assertPlacement({
+        testRelations: { or: { on: { relationName: { eq: 'foo' } } } }
+      } as unknown as Filter<TestEntity>)
+    ).not.toThrow()
+  })
+
   it('should reject join conditions at the root filter level', (): void => {
     expect(assertPlacement({ on: { stringType: { eq: 'foo' } } })).toThrow(
       '`on` conditions are only supported at the top level of a relation filter, not at the root filter level.'

--- a/packages/query-typeorm/__tests__/query/where.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/where.builder.spec.ts
@@ -36,6 +36,26 @@ describe('WhereBuilder', (): void => {
     expectSQLSnapshot({ numberType: { eq: 1 }, stringType: { like: 'foo%' }, boolType: { is: true } })
   })
 
+  describe('join conditions', (): void => {
+    const expectRelationSQLSnapshot = (filter: Filter<TestEntity>): void => {
+      const relationNames = { testRelations: { alias: 'testRelations', relations: {} } }
+      const selectQueryBuilder = createWhereBuilder().build(getQueryBuilder(), filter, relationNames, 'TestEntity')
+      const [sql, params] = selectQueryBuilder.getQueryAndParameters()
+
+      expect(formatSql(sql, { params })).toMatchSnapshot()
+    }
+
+    it('should not add join conditions to the where clause', (): void => {
+      expectSQLSnapshot({ on: { numberType: { eq: 1 } }, stringType: { eq: 'foo' } })
+    })
+
+    it('should not add a relations join conditions to the where clause', (): void => {
+      expectRelationSQLSnapshot({
+        testRelations: { on: { relationName: { eq: 'bar' } }, testRelationPk: { eq: 'foo' } }
+      })
+    })
+  })
+
   describe('and', (): void => {
     it('and multiple expressions together', (): void => {
       expectSQLSnapshot({

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -3,6 +3,8 @@ import {
   AggregateQueryField,
   Filter,
   getFilterFields,
+  ON_CONDITION_KEY,
+  OnConditionFilter,
   Paging,
   Query,
   SelectRelation,
@@ -22,6 +24,8 @@ import { RelationMetadata } from 'typeorm/metadata/RelationMetadata'
 import { SoftDeleteQueryBuilder } from 'typeorm/query-builder/SoftDeleteQueryBuilder'
 
 import { AggregateBuilder } from './aggregate.builder'
+import { OnConditionBuilder } from './on-condition.builder'
+import { assertValidOnConditionPlacement } from './on-condition.validator'
 import { SQLComparisonBuilder } from './sql-comparison.builder'
 import { WhereBuilder } from './where.builder'
 
@@ -59,7 +63,17 @@ interface Pageable<Entity> extends QueryBuilder<Entity> {
  * Nested record type
  */
 export interface NestedRecord<E = unknown> {
-  [keys: string]: NestedRecord<E>
+  [keys: string]: NestedRelationRecord<E>
+}
+
+/**
+ * @internal
+ *
+ * A relation referenced by a filter, together with the conditions to inject into its join.
+ */
+export interface NestedRelationRecord<E = unknown> {
+  children: NestedRecord<E>
+  on?: OnConditionFilter<E>
 }
 
 /**
@@ -71,6 +85,7 @@ export interface NestedRelationsAliased {
   [keys: string]: {
     alias: string
     relations: NestedRelationsAliased
+    on?: OnConditionFilter<unknown>
   }
 }
 
@@ -87,7 +102,10 @@ export class FilterQueryBuilder<Entity> {
     readonly whereBuilder: WhereBuilder<Entity> = new WhereBuilder<Entity>(
       new SQLComparisonBuilder<Entity>(SQLComparisonBuilder.DEFAULT_COMPARISON_MAP, repo)
     ),
-    readonly aggregateBuilder: AggregateBuilder<Entity> = new AggregateBuilder<Entity>(repo)
+    readonly aggregateBuilder: AggregateBuilder<Entity> = new AggregateBuilder<Entity>(repo),
+    readonly onConditionBuilder: OnConditionBuilder<Entity> = new OnConditionBuilder<Entity>(
+      new SQLComparisonBuilder<Entity>(SQLComparisonBuilder.DEFAULT_COMPARISON_MAP, repo)
+    )
   ) {
     this.virtualColumns = repo.metadata.columns
       .filter(({ isVirtualProperty }) => isVirtualProperty)
@@ -293,19 +311,23 @@ export class FilterQueryBuilder<Entity> {
     return referencedRelations.reduce((rqb, [relationKey, relation]) => {
       const relationAlias = relation.alias
       const relationChildren = relation.relations
+      const { condition, params } = this.onConditionBuilder.build(
+        relation.on as OnConditionFilter<Entity> | undefined,
+        relationAlias
+      )
 
       const selectRelation = selectRelations && selectRelations.find(({ name }) => name === relationKey)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 
       if (selectRelation) {
-        rqb = rqb.leftJoinAndSelect(`${alias ?? rqb.alias}.${relationKey}`, relationAlias)
+        rqb = rqb.leftJoinAndSelect(`${alias ?? rqb.alias}.${relationKey}`, relationAlias, condition, params)
         // Apply filter for the current relation
         rqb = this.applyFilter(rqb, selectRelation.query.filter, relationAlias)
         return this.applyRelationJoinsRecursive(rqb, relationChildren, selectRelation.query.relations, relationAlias)
       }
 
       return this.applyRelationJoinsRecursive(
-        rqb.leftJoin(`${alias ?? rqb.alias}.${relationKey}`, relationAlias),
+        rqb.leftJoin(`${alias ?? rqb.alias}.${relationKey}`, relationAlias, condition, params),
         relationChildren,
         [],
         relationAlias
@@ -354,12 +376,51 @@ export class FilterQueryBuilder<Entity> {
     filter: Filter<unknown> = {},
     selectRelations: SelectRelation<Entity>[] = []
   ): NestedRelationsAliased {
+    assertValidOnConditionPlacement(filter)
+
     const referencedRelations = this.getReferencedRelationsRecursive(metadata, filter, selectRelations)
     return this.injectRelationsAliasRecursive(referencedRelations)
   }
 
+  public getReferencedRelationsRecursive(
+    metadata: EntityMetadata,
+    filter: Filter<unknown>,
+    selectRelations: SelectRelation<Entity>[] = []
+  ): NestedRecord {
+    const selectedRelations = this.getSelectedRelationsRecursive(metadata, selectRelations)
+
+    return Object.keys(filter).reduce((relations: NestedRecord, field) => {
+      if (field === 'and' || field === 'or') {
+        return (filter[field] ?? []).reduce(
+          (merged, subFilter) => merge(merged, this.getReferencedRelationsRecursive(metadata, subFilter)),
+          relations
+        )
+      }
+
+      if (field === ON_CONDITION_KEY) {
+        return relations
+      }
+
+      const referencedRelation = metadata.relations.find((r) => r.propertyName === field)
+
+      if (!referencedRelation) {
+        return relations
+      }
+
+      const relationFilter = (filter as Record<string, Filter<unknown>>)[field]
+
+      return {
+        ...relations,
+        [field]: merge(relations[field], {
+          children: this.getReferencedRelationsRecursive(referencedRelation.inverseEntityMetadata, relationFilter),
+          ...(relationFilter.on ? { on: relationFilter.on } : undefined)
+        })
+      }
+    }, selectedRelations)
+  }
+
   private injectRelationsAliasRecursive(relations: NestedRecord, counter = new Map<string, number>()): NestedRelationsAliased {
-    return Object.entries(relations).reduce((prev, [name, children]) => {
+    return Object.entries(relations).reduce((prev, [name, relation]) => {
       const count = (counter.get(name) ?? -1) + 1
       const alias = count === 0 ? name : `${name}_${count}`
       counter.set(name, count)
@@ -368,63 +429,29 @@ export class FilterQueryBuilder<Entity> {
         ...prev,
         [name]: {
           alias,
-          relations: this.injectRelationsAliasRecursive(children, counter)
+          relations: this.injectRelationsAliasRecursive(relation.children, counter),
+          ...(relation.on ? { on: relation.on } : undefined)
         }
       }
     }, {})
   }
 
-  public getReferencedRelationsRecursive(
-    metadata: EntityMetadata,
-    filter: Filter<unknown>,
-    selectRelations: SelectRelation<Entity>[] = []
-  ): NestedRecord {
-    const referencedFields = Array.from(new Set(Object.keys(filter) as (keyof Filter<unknown>)[]))
-
-    const referencedRelations = selectRelations.reduce((relations, selectRelation) => {
+  private getSelectedRelationsRecursive(metadata: EntityMetadata, selectRelations: SelectRelation<Entity>[]): NestedRecord {
+    return selectRelations.reduce((relations: NestedRecord, selectRelation) => {
       const referencedRelation = metadata.relations.find((r) => r.propertyName === selectRelation.name)
 
       if (!referencedRelation) {
         return relations
       }
 
-      relations[selectRelation.name] = {}
-
-      if (selectRelation.query.relations) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        relations[selectRelation.name] = this.getReferencedRelationsRecursive(
-          referencedRelation.inverseEntityMetadata,
-          {},
-          selectRelation.query.relations
-        )
+      relations[selectRelation.name] = {
+        children: selectRelation.query.relations
+          ? this.getReferencedRelationsRecursive(referencedRelation.inverseEntityMetadata, {}, selectRelation.query.relations)
+          : {}
       }
 
       return relations
     }, {})
-
-    return referencedFields.reduce((prev, curr) => {
-      const currFilterValue = filter[curr]
-
-      if ((curr === 'and' || curr === 'or') && currFilterValue) {
-        for (const subFilter of currFilterValue) {
-          prev = merge(prev, this.getReferencedRelationsRecursive(metadata, subFilter, []))
-        }
-      }
-
-      const referencedRelation = metadata.relations.find((r) => r.propertyName === curr)
-
-      if (!referencedRelation) {
-        return prev
-      }
-
-      return {
-        ...prev,
-        [curr]: merge(
-          (prev as NestedRecord)[curr],
-          this.getReferencedRelationsRecursive(referencedRelation.inverseEntityMetadata, currFilterValue, [])
-        )
-      }
-    }, referencedRelations)
   }
 
   private get relationNames(): string[] {

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -97,15 +97,19 @@ export interface NestedRelationsAliased {
 export class FilterQueryBuilder<Entity> {
   private readonly virtualColumns: string[] = []
 
+  /**
+   * Join conditions only ever qualify a joined relation's own fields, never this entity's, so the
+   * builder is given no repository — the same reason {@link WhereBuilder} builds relation filters
+   * with a repository-less builder of its own.
+   */
+  private readonly onConditionBuilder = new OnConditionBuilder<unknown>()
+
   constructor(
     readonly repo: Repository<Entity>,
     readonly whereBuilder: WhereBuilder<Entity> = new WhereBuilder<Entity>(
       new SQLComparisonBuilder<Entity>(SQLComparisonBuilder.DEFAULT_COMPARISON_MAP, repo)
     ),
-    readonly aggregateBuilder: AggregateBuilder<Entity> = new AggregateBuilder<Entity>(repo),
-    readonly onConditionBuilder: OnConditionBuilder<Entity> = new OnConditionBuilder<Entity>(
-      new SQLComparisonBuilder<Entity>(SQLComparisonBuilder.DEFAULT_COMPARISON_MAP, repo)
-    )
+    readonly aggregateBuilder: AggregateBuilder<Entity> = new AggregateBuilder<Entity>(repo)
   ) {
     this.virtualColumns = repo.metadata.columns
       .filter(({ isVirtualProperty }) => isVirtualProperty)
@@ -311,10 +315,7 @@ export class FilterQueryBuilder<Entity> {
     return referencedRelations.reduce((rqb, [relationKey, relation]) => {
       const relationAlias = relation.alias
       const relationChildren = relation.relations
-      const { condition, params } = this.onConditionBuilder.build(
-        relation.on as OnConditionFilter<Entity> | undefined,
-        relationAlias
-      )
+      const { condition, params } = this.onConditionBuilder.build(relation.on, relationAlias)
 
       const selectRelation = selectRelations && selectRelations.find(({ name }) => name === relationKey)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/query-typeorm/src/query/index.ts
+++ b/packages/query-typeorm/src/query/index.ts
@@ -1,5 +1,7 @@
 export * from './aggregate.builder'
 export * from './filter-query.builder'
+export * from './on-condition.builder'
+export * from './on-condition.validator'
 export * from './relation-query.builder'
 export * from './sql-comparison.builder'
 export * from './where.builder'

--- a/packages/query-typeorm/src/query/on-condition.builder.ts
+++ b/packages/query-typeorm/src/query/on-condition.builder.ts
@@ -1,0 +1,117 @@
+import { FilterComparisons, FilterFieldComparison, OnConditionFilter } from '@ptc-org/nestjs-query-core'
+import { ObjectLiteral } from 'typeorm'
+
+import { EntityComparisonField, SQLComparisonBuilder } from './sql-comparison.builder'
+
+/**
+ * @internal
+ *
+ * A SQL fragment and its bound parameters, in the shape `typeorm`'s join methods expect for their
+ * `condition` and `parameters` arguments.
+ */
+export interface OnConditionSQL {
+  condition?: string
+  params?: ObjectLiteral
+}
+
+const EMPTY_ON_CONDITION: OnConditionSQL = { condition: undefined, params: undefined }
+
+function combineOnConditions(conditions: OnConditionSQL[], operator: string): OnConditionSQL {
+  const present = conditions.filter(({ condition }) => condition)
+
+  if (!present.length) {
+    return EMPTY_ON_CONDITION
+  }
+
+  const params = present.reduce<ObjectLiteral>((merged, { params: conditionParams }) => ({ ...merged, ...conditionParams }), {})
+
+  if (present.length === 1) {
+    return { condition: present[0].condition, params }
+  }
+
+  return { condition: `(${present.map(({ condition }) => condition).join(operator)})`, params }
+}
+
+/**
+ * @internal
+ *
+ * Builds the extra `JOIN ... ON` fragment for the `on` key of a relation filter.
+ *
+ * Every comparison is delegated to the {@link SQLComparisonBuilder}, so values are always bound as
+ * parameters rather than interpolated into the SQL.
+ */
+export class OnConditionBuilder<Entity> {
+  constructor(private readonly sqlComparisonBuilder: SQLComparisonBuilder<Entity> = new SQLComparisonBuilder<Entity>()) {}
+
+  /**
+   * Builds the SQL fragment for a relation's join conditions.
+   *
+   * @param onCondition - the `on` conditions of the relation filter, if any.
+   * @param alias - the alias of the relation being joined.
+   */
+  public build(onCondition: OnConditionFilter<Entity> | undefined, alias: string): OnConditionSQL {
+    if (!onCondition) {
+      return EMPTY_ON_CONDITION
+    }
+
+    const conditions = Object.keys(onCondition).map((field) => this.buildField(onCondition, field, alias))
+
+    return combineOnConditions(conditions, ' AND ')
+  }
+
+  private buildField(onCondition: OnConditionFilter<Entity>, field: string, alias: string): OnConditionSQL {
+    if (field === 'and') {
+      return this.buildGrouping(onCondition.and, alias, ' AND ')
+    }
+
+    if (field === 'or') {
+      return this.buildGrouping(onCondition.or, alias, ' OR ')
+    }
+
+    const entityField = field as keyof Entity
+
+    return this.buildComparison(entityField, this.getComparison(onCondition, entityField), alias)
+  }
+
+  private buildGrouping(onConditions: OnConditionFilter<Entity>[] | undefined, alias: string, operator: string): OnConditionSQL {
+    if (!Array.isArray(onConditions)) {
+      return EMPTY_ON_CONDITION
+    }
+
+    return combineOnConditions(
+      onConditions.map((onCondition) => this.build(onCondition, alias)),
+      operator
+    )
+  }
+
+  private buildComparison<F extends keyof Entity>(
+    field: F,
+    comparison: FilterFieldComparison<Entity[F]> | undefined,
+    alias: string
+  ): OnConditionSQL {
+    if (!comparison || typeof comparison !== 'object') {
+      return EMPTY_ON_CONDITION
+    }
+
+    const operators = Object.keys(comparison) as (keyof FilterFieldComparison<Entity[F]>)[]
+    const comparisons = operators.map((operator) => {
+      const { sql, params } = this.sqlComparisonBuilder.build(
+        field,
+        operator,
+        comparison[operator] as EntityComparisonField<Entity, F>,
+        alias
+      )
+
+      return { condition: sql, params }
+    })
+
+    return combineOnConditions(comparisons, ' OR ')
+  }
+
+  private getComparison<K extends keyof FilterComparisons<Entity>>(
+    onCondition: FilterComparisons<Entity>,
+    field: K
+  ): FilterFieldComparison<Entity[K]> {
+    return onCondition[field] as FilterFieldComparison<Entity[K]>
+  }
+}

--- a/packages/query-typeorm/src/query/on-condition.validator.ts
+++ b/packages/query-typeorm/src/query/on-condition.validator.ts
@@ -1,0 +1,65 @@
+import { Filter, ON_CONDITION_KEY } from '@ptc-org/nestjs-query-core'
+
+/**
+ * Thrown when a filter carries an `on` key in a position that cannot be attached to a
+ * `JOIN ... ON` clause.
+ */
+export class InvalidOnConditionPlacementError extends Error {
+  constructor(detail: string) {
+    super(`\`on\` conditions are only supported at the top level of a relation filter, ${detail}.`)
+
+    this.name = 'InvalidOnConditionPlacementError'
+  }
+}
+
+function isFilterLike(filter: unknown): filter is Record<string, unknown> {
+  return !!filter && typeof filter === 'object'
+}
+
+function hasOnCondition(filter: unknown): boolean {
+  return isFilterLike(filter) && ON_CONDITION_KEY in filter
+}
+
+function assertNoRootOnCondition(filter: Filter<unknown>): void {
+  if (hasOnCondition(filter)) {
+    throw new InvalidOnConditionPlacementError('not at the root filter level')
+  }
+}
+
+function assertNoOnConditionInsideBooleanExpression(filter: unknown): void {
+  if (!isFilterLike(filter)) {
+    return
+  }
+
+  for (const [key, value] of Object.entries(filter)) {
+    if (key !== 'and' && key !== 'or') {
+      assertNoOnConditionInsideBooleanExpression(value)
+      continue
+    }
+
+    if (!Array.isArray(value)) {
+      continue
+    }
+
+    for (const subFilter of value) {
+      if (hasOnCondition(subFilter)) {
+        throw new InvalidOnConditionPlacementError('not inside an `and`/`or` expression')
+      }
+
+      assertNoOnConditionInsideBooleanExpression(subFilter)
+    }
+  }
+}
+
+/**
+ * @internal
+ *
+ * Asserts that every `on` key in a filter sits at the top level of a relation filter, the only
+ * position from which it can be injected into a join.
+ *
+ * @param filter - the root filter to validate.
+ */
+export function assertValidOnConditionPlacement(filter: Filter<unknown>): void {
+  assertNoRootOnCondition(filter)
+  assertNoOnConditionInsideBooleanExpression(filter)
+}

--- a/packages/query-typeorm/src/query/where.builder.ts
+++ b/packages/query-typeorm/src/query/where.builder.ts
@@ -1,4 +1,4 @@
-import { Filter, FilterComparisons, FilterFieldComparison } from '@ptc-org/nestjs-query-core'
+import { Filter, FilterComparisons, FilterFieldComparison, ON_CONDITION_KEY } from '@ptc-org/nestjs-query-core'
 import { Brackets } from 'typeorm'
 
 import type { WhereExpressionBuilder } from 'typeorm'
@@ -105,7 +105,7 @@ export class WhereBuilder<Entity> {
     alias: string | undefined
   ): Where {
     return Object.keys(filter).reduce((w, field) => {
-      if (field !== 'and' && field !== 'or') {
+      if (field !== 'and' && field !== 'or' && field !== ON_CONDITION_KEY) {
         return this.withFilterComparison(
           where,
           field as keyof Entity,


### PR DESCRIPTION
## Summary

Adds an `on` key inside a **relation** deep filter. Conditions under `on` are injected into that relation's SQL **`JOIN ... ON`** clause instead of the `WHERE` clause, which preserves `LEFT JOIN` semantics — parent rows are kept when no child matches.

Filtering on a relation today always constrains the parent: `filter: { subTasks: { completed: { is: false } } }` drops every todo item that has no uncompleted subtask. There is currently no way to say "return all parents, but only join the children I care about", which is what you need for soft-delete/void/draft flags on a relation, and for `LEFT JOIN`-shaped reporting queries. The usual workarounds are a dedicated view entity per condition, or a custom `QueryService` that reaches for the raw query builder.

```graphql
{
  todoItems(filter: {
    subTasks: {
      on: { completed: { is: false } }   # -> JOIN ON
      title: { like: "%urgent%" }        # -> WHERE
    }
  }) { edges { node { id title } } }
}
```

This has been running in production at [Ailo](https://www.ailo.io) for some months as a `patch-package` patch against 7.0.1 and then 9.4.0; this PR is the same mechanism ported to the real sources on `master` (10.0.3), with types, tests and docs. It let us delete a family of view entities that existed only to carry hardcoded join conditions.

## How it works

The `on` value travels with its relation through the existing relation-resolution pipeline and is emitted as an extra JOIN ON condition:

1. **`getReferencedRelationsRecursive`** captures each relation's `on` where the relation is first discovered — the `NestedRecord` node becomes `{ children, on? }`. `and`/`or` branches still merge via `lodash.merge`, so duplicate `on`s for the same relation combine.
2. **`injectRelationsAliasRecursive`** carries `on` onto the aliased entry (`{ alias, relations, on? }`).
3. **`applyRelationJoinsRecursive`** turns `relation.on` into a `{ condition, params }` fragment via the new `OnConditionBuilder` and passes it to `leftJoin` / `leftJoinAndSelect`. TypeORM ANDs and parenthesises it onto the relation's FK condition (`... ON <fk> AND (<condition>)`).
4. **`WhereBuilder.filterFields`** skips the `on` key so it never leaks into `WHERE`. `getFilterFields` and `FilterBuilder` in `core` skip it too, so it is never mistaken for a field or relation name.

Per-comparison SQL is produced by the library's own `SQLComparisonBuilder` — the same primitive the `WHERE` path uses — so **values are always bound parameters**, never interpolated, and field names and operators are whitelisted by the generated input type. Combined with TypeORM ANDing the fragment onto the FK condition, an `on` can only ever *narrow* a join: it cannot inject SQL, build a subquery, or broaden the result set.

## Constraint: `on` is only valid at the top level of a relation filter

`on` only means something where there is a relation join to attach it to. Placing it at the **root filter level** or **inside an `and`/`or`** is rejected up front by `assertValidOnConditionPlacement` (throwing `InvalidOnConditionPlacementError`) rather than being silently dropped. Valid placements — a relation's top level, including nested child relations, and relations referenced inside a top-level `and`/`or` — work as expected.

The GraphQL type system can't express "only on relation filters" here, because the same generated filter type is reused for the root and for relations, so this is a runtime check with a matching note in the generated field's description.

## Changes

| Package | Change |
|---|---|
| `core` | `Filter<T>` gains `on?: OnConditionFilter<T>` (own-field comparisons plus `and`/`or`, no relations); `ON_CONDITION_KEY` exported; `getFilterFields` and `FilterBuilder` skip `on` |
| `query-typeorm` | New `OnConditionBuilder` and `assertValidOnConditionPlacement`; `on` carried through the relations tree; fragment passed to `leftJoin`/`leftJoinAndSelect`; `where.builder` skips `on` |
| `query-graphql` | `FilterConstructor` gains `prototype: object`, which every class already satisfies structurally — it removes a double cast when decorating the memoized relation filter type |
| `query-graphql` | Adds a documented, nullable `on: <T>OnConditionFilter` (depth 0) to generated relation filter types |
| `docs` | New sections in `concepts/queries` and `graphql/queries/filtering` |

The second commit is a self-review fix worth calling out. The on-condition builder was originally given a `SQLComparisonBuilder` holding the **root** entity's repository, which `getCol` consults to expand virtual columns. But an `on` condition only ever qualifies the *joined relation's* fields, so the root metadata is always the wrong metadata: a root-entity virtual column whose name matched a relation field would have been spliced into that relation's `ON` clause. Relation join conditions are now built with a repository-less comparison builder, which is exactly what `WhereBuilder.withRelationFilter` already does for relation filters. No existing snapshot changed. Neither path expands a *relation's* own virtual columns — a pre-existing shared limitation, not something this PR introduces.

## Test plan

- [x] `nx run-many -t lint test build --all` green (9 projects)
- [x] Unit tests for `OnConditionBuilder` (incl. asserting values are bound, not interpolated) and the placement validator
- [x] SQL-snapshot tests in `filter-query.builder.spec.ts`: JOIN ON instead of WHERE, `on` + WHERE on the same relation, `on` with `and`/`or`, nested child relation, merging when a relation appears twice, selected (`leftJoinAndSelect`) relations, and both misplacement errors
- [x] `where.builder.spec.ts` coverage that `on` never reaches `WHERE`
- [x] `filter.type.spec.ts` + schema snapshots for the generated `on` field
- [x] Multi-parameter comparisons inside `on` — `in`/`notIn` (`:...param` spread) and `between` (two bound params), at both the unit and JOIN-ON-SQL level
- [x] Paging interaction: a relation whose *only* filter content is an `on` still pages correctly — `take`/`skip` for a to-many relation, `limit`/`offset` for a one-to-one — asserted on the query builder's paging state, not just a snapshot
- [x] **e2e suites** — I could not run these locally (no Docker), but CI has since run them green: postgres and mysql on both 22.x and 24.x, plus `federation-e2e-test`

`on-condition.builder.ts` and `on-condition.validator.ts` are at 100% statement, branch, function and line coverage locally. Codecov's patch report looks to be reading a stale upload — its per-file numbers for `on-condition.builder.ts` are unchanged from its first comment despite four tests being added to that file since, and it warns at the top that the Codecov app isn't installed on this repo. Every entry in its table is "0 Missing and N partials", i.e. no line goes unexecuted; the partials are individual short-circuits on multi-operand lines such as `field !== 'and' && field !== 'or' && field !== ON_CONDITION_KEY`.

<sub>Note on the red `check (24.x, test)`: the failing project is `query-typegoose`, which this PR does not touch. `mongodb-memory-server` failed to fetch its binary (`ENOENT ... rename 'mongodb-linux-x86_64-ubuntu2404-8.2.6.tgz.downloading' -> '...tgz'`) and every other error in that job is a cascading hook timeout from the missing server — no assertion failed. The same project passes on 22.x in the same run, and locally on this branch (250 tests), as does the full workspace. It shows up here rather than on dependency PRs because touching `packages/core` puts every package into `nx affected`. A re-run should clear it; I don't have permission to trigger one.</sub>

## Points I'd like your call on

1. **`NestedRecord` shape change.** `{ [k]: NestedRecord }` becomes `{ [k]: { children, on? } }`. It's marked `@internal`, but `getReferencedRelationsRecursive` is `public`, so anyone reading that tree is affected. Happy to switch to a non-breaking alternative (e.g. a parallel `on` map keyed by relation path) if you'd rather not take the shape change.
2. **Schema addition is unconditional.** Every filterable relation input type gains an `on` field and a new `<T>OnConditionFilter` input type appears in the SDL. Additive and non-breaking for queries, but it churns generated schemas for all users with no opt-out. Should this sit behind a `QueryOptions` flag, in the style of `allowedBooleanExpressions`?
3. **`on` is typeorm-only, but `Filter<T>` lives in `core`,** so it now type-checks for sequelize/mongoose/mikro-orm/typegoose, where it is ignored. All those packages build and test green. Docs carry the usual "typeorm only!" warning, but the type promises something one adapter honours. Alternative is a typeorm-local filter type.
4. **In-memory `applyFilter` ignores `on`** (`FilterBuilder` skips the key), since there is no join in memory. Throwing, or treating it as an AND of its conditions, are both defensible — I picked "ignore" to match the `WHERE`-path skip.
5. **Naming.** `on` is short and could collide with a DTO field genuinely called `on`, and there's no escape hatch. Also open on `OnCondition` as the type suffix versus something like `JoinOn`.

Happy to reshape any of the above — the mechanism is the part I care about, not the spelling.

## Known limitations

Two rough edges I found reviewing my own diff and chose to document rather than grow the PR over. Say the word if you'd rather either were fixed here.

- **A confusing error for a plausible spelling.** `relations: [{ name: 'x', query: { filter: { on: … } } }]` puts `on` at the root of that relation's own query filter, so validation rejects it with "not at the root filter level" — technically true, unhelpful in context. The supported spelling is `filter: { x: { on: … } }` alongside `relations: [{ name: 'x' }]`, which works and is tested. Threading `on` through `SelectRelation` would fix it properly.
- **Two `on`s for the same relation merge via `lodash.merge`.** For plain comparisons that is a clean AND, and is snapshot-tested. If the same relation carries `on: { and: [ … ] }` in two places, lodash merges those arrays by index, which could surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `on` key to relation filters that injects conditions into the relation's SQL `JOIN ... ON` clause instead of the `WHERE` clause, preserving `LEFT JOIN` semantics so parent records without matching children are still returned. It's opt-in in GraphQL via `@QueryOptions({ enableRelationJoinConditions: true })` on the relation's DTO, and the key can be renamed with `{ field: 'joinOn' }`.

- `on` is typeorm-only; `sequelize`, `mongoose`, `typegoose`, and `mikro-orm` throw from `forFeature` at startup for a DTO that enables it.
- Placement is runtime-validated; an `on` at the root filter level or inside an `and`/`or` throws.
- Values are always bound parameters, and join conditions use a repository-less comparison builder so a root-entity virtual column can't appear in the relation's ON clause.
- A relation whose only filter content is an `on` pages by skip/take or limit/offset rather than the distinct-id subquery.
- For to-many joins, queries, counts, and paging account for one row per child; only aggregates count each parent once per child (true of any relation filter, not just `on`).
- Enabling the option throws at schema generation when the DTO has a filterable member named like the configured key.
- `NestedRecord` becomes `{ [k]: { children, on? } }`; since `getReferencedRelationsRecursive` is public, direct consumers break.

<sup>Written for commit 9d9ef911449072113f6bef25091d0cd7b44499af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

