### PR TITLE
fix(query-typeorm): apply custom SQLComparisonBuilder to relation filters

### DIFF
--- a/packages/query-typeorm/__tests__/query/where.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/where.builder.spec.ts
@@ -1,10 +1,11 @@
-import { Filter } from '@ptc-org/nestjs-query-core'
+import { Filter, FilterComparisonOperators } from '@ptc-org/nestjs-query-core'
 import { format as formatSql } from 'sql-formatter'
-import { DataSource } from 'typeorm'
+import { DataSource, Repository } from 'typeorm'
 
-import { WhereBuilder } from '../../src/query'
+import { EntityComparisonField, SQLComparisonBuilder, WhereBuilder } from '../../src/query'
 import { createTestConnection } from '../__fixtures__/connection.fixture'
 import { TestEntity } from '../__fixtures__/test.entity'
+import { TestRelation } from '../__fixtures__/test-relation.entity'
 
 describe('WhereBuilder', (): void => {
   let dataSource: DataSource
@@ -93,6 +94,80 @@ describe('WhereBuilder', (): void => {
 
     it('should properly group OR with a sibling field comparison', (): void => {
       expectSQLSnapshot({ or: [{ numberType: { eq: 2 } }, { numberType: { gt: 10 } }], stringType: { eq: 'foo' } })
+    })
+  })
+
+  describe('custom SQLComparisonBuilder', (): void => {
+    class UpperCaseComparisonBuilder<Entity> extends SQLComparisonBuilder<Entity> {
+      public build<F extends keyof Entity>(
+        field: F,
+        cmp: FilterComparisonOperators<Entity[F]>,
+        val: EntityComparisonField<Entity, F>,
+        alias?: string
+      ) {
+        const { sql, params } = super.build(field, cmp, val, alias)
+
+        return { sql: sql.replace(/^(\S+)/, 'UPPER($1)'), params }
+      }
+    }
+
+    class CollatedComparisonBuilder<Entity> extends SQLComparisonBuilder<Entity> {
+      constructor(private readonly collation: string) {
+        super()
+      }
+
+      public forRelation<Relation>(): SQLComparisonBuilder<Relation> {
+        return new CollatedComparisonBuilder<Relation>(this.collation)
+      }
+
+      public build<F extends keyof Entity>(
+        field: F,
+        cmp: FilterComparisonOperators<Entity[F]>,
+        val: EntityComparisonField<Entity, F>,
+        alias?: string
+      ) {
+        const { sql, params } = super.build(field, cmp, val, alias)
+
+        return { sql: `${sql} COLLATE ${this.collation}`, params }
+      }
+    }
+
+    const relationNames = { testRelations: { alias: 'TestRelation', relations: {} } }
+    const relationFilter = { testRelations: { relationName: { eq: 'foo' } } } as Filter<TestEntity>
+
+    const buildRelationFilterSql = (sqlComparisonBuilder: SQLComparisonBuilder<TestEntity>): string => {
+      const [sql] = new WhereBuilder<TestEntity>(sqlComparisonBuilder)
+        .build(getQueryBuilder(), relationFilter, relationNames, 'TestEntity')
+        .getQueryAndParameters()
+
+      return sql
+    }
+
+    const createRootRepoWithVirtualColumn = (databasePath: keyof TestRelation) =>
+      ({
+        metadata: {
+          columns: [{ databasePath, isVirtualProperty: true, query: (alias: string) => `SELECT 1 FROM ${alias}` }]
+        }
+      }) as unknown as Repository<TestEntity>
+
+    it('should apply the custom comparison builder to relation comparisons', (): void => {
+      expect(buildRelationFilterSql(new UpperCaseComparisonBuilder<TestEntity>())).toContain('UPPER(TestRelation.relationName)')
+    })
+
+    it('should let a subclass with its own constructor signature derive its relation comparison builder', (): void => {
+      expect(buildRelationFilterSql(new CollatedComparisonBuilder<TestEntity>('BINARY'))).toContain('COLLATE BINARY')
+    })
+
+    it('should not resolve relation fields against the root entity metadata', (): void => {
+      const sql = buildRelationFilterSql(
+        new SQLComparisonBuilder<TestEntity>(
+          SQLComparisonBuilder.DEFAULT_COMPARISON_MAP,
+          createRootRepoWithVirtualColumn('relationName')
+        )
+      )
+
+      expect(sql).toContain('TestRelation.relationName')
+      expect(sql).not.toContain('SELECT 1 FROM')
     })
   })
 })

--- a/packages/query-typeorm/src/query/sql-comparison.builder.ts
+++ b/packages/query-typeorm/src/query/sql-comparison.builder.ts
@@ -93,6 +93,25 @@ export class SQLComparisonBuilder<Entity> {
     throw new Error(`unknown operator ${JSON.stringify(cmp)}`)
   }
 
+  /**
+   * Derives the builder used for comparisons on a relation of `Entity`.
+   *
+   * The derived builder is of the same class and carries the same comparison map, so custom
+   * operators and SQL transforms apply to relation fields as well as root entity fields.
+   *
+   * It deliberately carries no repository: `repo` describes the root entity, and resolving a
+   * relation's field names against root entity metadata would expand the wrong virtual columns.
+   *
+   * Subclasses that declare a constructor signature other than `SQLComparisonBuilder`'s must
+   * override this method, since the default implementation constructs the subclass with a
+   * comparison map as its only argument.
+   */
+  public forRelation<Relation>(): SQLComparisonBuilder<Relation> {
+    const BuilderClass = this.constructor as new (comparisonMap: Record<string, string>) => SQLComparisonBuilder<Relation>
+
+    return new BuilderClass(this.comparisonMap)
+  }
+
   private createComparisonSQL<F extends keyof Entity>(
     cmp: string,
     col: string,

--- a/packages/query-typeorm/src/query/where.builder.ts
+++ b/packages/query-typeorm/src/query/where.builder.ts
@@ -156,7 +156,7 @@ export class WhereBuilder<Entity> {
   ): Where {
     return where.andWhere(
       new Brackets((qb) => {
-        const relationWhere = new WhereBuilder<Entity[T]>()
+        const relationWhere = new WhereBuilder<Entity[T]>(this.sqlComparisonBuilder.forRelation<Entity[T]>())
         const nestedRelationAliased = relationNames[field as string]
         const nestedRelationAliasedAlias = nestedRelationAliased.alias
         const nestedRelationAliasedRelationNames = nestedRelationAliased.relations


### PR DESCRIPTION
Fixes upstream issue [#381](https://github.com/TriPSs/nestjs-query/issues/381) — closed `NOT_PLANNED` on 2026-08-27 in a repository cleanup sweep rather than fixed, and still reproducible on `master`.

Branched off `origin/master`, independent of any other work, so it can go upstream on its own.

## The bug

A custom `SQLComparisonBuilder` injected via `TypeOrmQueryServiceOpts.filterQueryBuilder` applied to root-entity fields only. As soon as a filter descended into a relation, `WhereBuilder.withRelationFilter` did:

```ts
const relationWhere = new WhereBuilder<Entity[T]>()
```

with no arguments — discarding the custom builder and its comparison map, so `relation.field` comparisons silently fell back to the defaults. People subclass `SQLComparisonBuilder` to add operators or SQL transforms, and half of their filter quietly ignored it.

## The fix

`SQLComparisonBuilder.forRelation()` derives a builder for a relation: same class, so subclasses survive; same comparison map, so custom operators carry over. `withRelationFilter` uses it. One behavioural line.

**Dropping the repository is deliberate, not an oversight.** `repo` describes the root entity, and `getCol` resolves virtual columns by matching `databasePath` against the field name. Reusing the root instance would make a root virtual column expand inside a relation's `WHERE` whenever the names collided — a new bug in exchange for fixing this one. Omitting it leaves relation virtual-column behaviour exactly as it is today, so this change is behaviour-neutral except for the fix. There's a test guarding it.

`forRelation()` is public and overridable because the default implementation constructs `this.constructor` with the comparison map as its only argument, which is wrong for a subclass declaring a different constructor signature. Documented in TSDoc, covered by a test using such a subclass.

## Test plan

Written test-first; both new assertions failed on `master` with the plain default SQL (`(TestRelation.relationName = ?)`), proving the custom builder never reached the relation.

- [x] Subclass overriding `build` reaches relation comparisons (`UPPER(TestRelation.relationName)`)
- [x] Subclass with its own constructor overriding `forRelation` (`COLLATE BINARY`)
- [x] Regression guard: a root virtual column whose `databasePath` collides with a relation field name does not expand into relation SQL
- [x] `nx run-many -t lint test build -p core,query-typeorm,query-graphql` green
- [x] `nx run-many -t test --all` green, 8 projects
- [x] No snapshot changed — expected, since behaviour only differs when a non-default comparison builder is injected

## Deliberately out of scope

**Relation virtual columns still don't expand.** Making them work needs the relation's `EntityMetadata` threaded through the relation tree. Today's behaviour is preserved rather than improved.

**`RelationQueryBuilder` has the same bug in different plumbing.** Its constructor does `new FilterQueryBuilder<Relation>(this.relationRepo)`, and `RelationQueryService.getRelationQueryBuilder` does `new RelationQueryBuilder(this.repo, name)` — neither sees `opts.filterQueryBuilder`, so a custom builder never reaches `queryRelations`, `countRelations`, `aggregateRelations` or `findRelation`. Not a one-liner: the relation builder legitimately needs a `FilterQueryBuilder` bound to the *relation's* repository, so a fix needs either a factory option on `TypeOrmQueryServiceOpts` or a `FilterQueryBuilder.forRepository(repo)` clone — a public-API addition with a naming question and coverage across four code paths. Deserves its own issue and PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@ptc-org/nestjs-query-typeorm` so a custom `SQLComparisonBuilder` injected via `TypeOrmQueryServiceOpts.filterQueryBuilder` now applies to relation filters too, not just root entity fields. Previously, relation comparisons silently fell back to default SQL.

- Adds `SQLComparisonBuilder.forRelation()` to derive a relation builder of the same class and comparison map.
- Subclasses with a constructor other than `(comparisonMap)` must override `forRelation()`.
- Relation virtual columns still don't expand; behavior unchanged.
- Includes tests covering custom builders, custom constructors, and a regression guard.

<sup>Written for commit 25ba5566c9166b887196973c6559520fde2cbc1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TriPSs/nestjs-query/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

